### PR TITLE
allow paths specifying files to be found regardless of file name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "brianium/paratest",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "phpunit/phpunit": ">=3.7.8"
     },
     "minimum-stability": "dev",
     "type": "library",

--- a/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
@@ -7,7 +7,8 @@ class SuiteLoader
     protected $files = array();
     protected $loadedSuites = array();
 
-    private static $testPattern = '/.+Test.php$/';
+    private static $testPattern = '/.+Test\.php$/';
+    private static $filePattern = '/.+\.php$/';
     private static $dotPattern = '/([.]+)$/';
     private static $testMethod = '/^test/';
 
@@ -33,7 +34,7 @@ class SuiteLoader
 
     public function load($path)
     {
-        if(!file_exists($path)) 
+        if(!file_exists($path))
             throw new \InvalidArgumentException("$path is not a valid directory or file");
         if(is_dir($path))
             $this->loadDir($path);
@@ -51,13 +52,15 @@ class SuiteLoader
 
     private function loadFile($path)
     {
-        $this->tryLoadTests($path);
+        $this->tryLoadTests($path, true);
     }
 
-    private function tryLoadTests($path)
+    private function tryLoadTests($path, $relaxTestPattern = false)
     {
         if(preg_match(self::$testPattern, $path))
-                $this->files[] = $path;
+            $this->files[] = $path;
+        elseif($relaxTestPattern && preg_match(self::$filePattern, $path))
+            $this->files[] = $path;
 
         if(!preg_match(self::$dotPattern, $path) && is_dir($path))
             $this->loadDir($path);


### PR DESCRIPTION
I ran into trouble doing things like --path WebDriverDemo.php. When I'm specifying an individual file, I think it makes sense not to require it to conform to /.+Test.php/.

Also, include phpunit/phpunit in composer for those of us who like to run it from within the directory :-)
