### PR TITLE
TestBase call method to call protected/private methods

### DIFF
--- a/test/Library/TestBaseTest.php
+++ b/test/Library/TestBaseTest.php
@@ -1,0 +1,38 @@
+<?php namespace ParaTest\Runners\PHPUnit;
+
+class TestBaseClass
+{
+    protected function helloWorld($a = 0, $b = 0, $c = 0)
+    {
+        if ($a || $b || $c) {
+            return "Hello World $a $b $c";
+        }
+        return 'Hello World';
+    }
+
+    protected static function helloAll()
+    {
+        return 'Hello All';
+    }
+}
+
+class TestBaseTest extends \TestBase
+{
+    public function testCallCallsProtectedMethods()
+    {
+        $testBaseClass = new TestBaseClass;
+        $this->assertEquals('Hello World', $this->call($testBaseClass, 'helloWorld'));
+    }
+
+    public function testCallStaticCallsProtectedMethods()
+    {
+        $testBaseClass = new TestBaseClass;
+        $this->assertEquals('Hello All', $this->call($testBaseClass, 'helloAll'));
+    }
+
+    public function testCallPassesArguments()
+    {
+        $testBaseClass = new TestBaseClass;
+        $this->assertEquals('Hello World 2 3 4', $this->call($testBaseClass, 'helloWorld', 2, 3, 4));
+    }
+}

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -23,4 +23,54 @@ class TestBase extends PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         return $prop;
     }
+
+    /**
+     * Calls an object method even if it is protected or private
+     * @param Object $object the object to call a method on
+     * @param string $methodName the method name to be called
+     * @param mixed $args 0 or more arguments passed in the function
+     * @return mixed returns what the object's method call will return
+     */
+    public function call($object, $methodName, $args = null)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        array_shift($args);
+        return self::_callMethod($object, $methodName, $args);
+    }
+
+    /**
+     * Calls a class method even if it is protected or private
+     * @param Class $class the class to call a method on
+     * @param string $methodName the method name to be called
+     * @param mixed $args 0 or more arguments passed in the function
+     * @return mixed returns what the object's method call will return
+     */
+    public function callStatic($class, $methodName, $args = null)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        array_shift($args);
+        return self::_callMethod($class, $methodName, $args);
+    }
+
+    static protected function _callMethod($objectOrClassName, $methodName, $args = null)
+    {
+        $isStatic = is_string($objectOrClassName);
+
+        if (!$isStatic) {
+            if (!is_object($objectOrClassName)) {
+                throw new Exception('Method call on non existent object or class');
+            }
+        }
+
+        $class = $isStatic ? $objectOrClassName : get_class($objectOrClassName);
+        $object = $isStatic ? null : $objectOrClassName;
+
+        $reflectionClass = new ReflectionClass($class);
+        $method = $reflectionClass->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
 }


### PR DESCRIPTION
Includes helper methods `call` and `callStatic` to be used in test classes in order to call protected and private methods.
