### PR TITLE
Modified Reader to display the progress of the tests as PHPUnit

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -44,10 +44,35 @@ class Reader extends MetaProvider
         $suites = $this->isSingle ? $this->suites : $this->suites[0]->suites;
         foreach($suites as $suite) {
             foreach($suite->cases as $case) {
-                if($case->failures) $feedback .= 'F';
-                else if ($case->errors) $feedback .= 'E';
-                else $feedback .= '.';
+                \ParaTest\Runners\PHPUnit\ResultPrinter::$casesProcessed++;
+                $feedback .= $this->getCaseFeedback($case);
             }
+        }
+        return $feedback;
+    }
+
+    function getCaseFeedback($case)
+    {
+        $feedback = '';
+        if ($case->failures)
+            $feedback .= 'F';
+        else if ($case->errors)
+            $feedback .= 'E';
+        else
+            $feedback .= '.';
+
+        $casesProcessed = \ParaTest\Runners\PHPUnit\ResultPrinter::$casesProcessed;
+        $totalCases = \ParaTest\Runners\PHPUnit\ResultPrinter::$totalCases;
+        $percent = floor(($casesProcessed * 100) / $totalCases);
+        if (($casesProcessed % 100) == 0) {
+            $feedback .= sprintf(
+                ' %' . strlen($totalCases) . 'd / %' .
+                       strlen($totalCases) . 'd (%3s%%)',
+
+                $casesProcessed,
+                $totalCases,
+                $percent
+              ) . PHP_EOL;
         }
         return $feedback;
     }

--- a/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
+++ b/src/ParaTest/Runners/PHPUnit/ResultPrinter.php
@@ -7,6 +7,8 @@ class ResultPrinter
 {
     protected $suites = array();
     protected $results;
+    public static $casesProcessed = 0;
+    public static $totalCases = 0;
 
     public function __construct(LogInterpreter $results)
     {
@@ -16,6 +18,7 @@ class ResultPrinter
     public function addTest(ExecutableTest $suite)
     {
         $this->suites[] = $suite;
+        self::$totalCases = self::$totalCases + count($suite->getFunctions());
         return $this;
     }
 


### PR DESCRIPTION
Modified results printer to output progress as it is on PHPUnit.

The results is similar to:
....................................................................................................   100 / 13040 (  0%)
....................................................................................................   200 / 13040 (  1%)
....................................................................................................   300 / 13040 (  2%)
....................................................................................................   400 / 13040 (  3%)
....................................................................................................   500 / 13040 (  3%)
....................................................................................................   600 / 13040 (  4%)
....................................................................................................   700 / 13040 (  5%)
....................................................................................................   800 / 13040 (  6%)
