### PR TITLE
Improve CPU usage of main process by sleeping while going through child processes

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -30,6 +30,7 @@ class Runner
             foreach($this->running as $key => $test)
                 if(!$this->testIsStillRunning($test)) unset($this->running[$key]);
             $this->fillRunQueue();
+            usleep(10000);
         }
         $this->complete();
     }


### PR DESCRIPTION
The main process now consumes more than 80% of one CPU, when in the while loop of `Runner::run`
Having the main process sleep for 10 ms significantly significantly decreases the CPU usage of the main process.
From tests on my dev machine, If the process sleeps for 2-3 ms, the process still consumes more than 50% of the CPU.
Also having it sleep for more than 100ms significantly delays the total time.
Thus the somehow arbitrary 10ms. 
