### PR TITLE
Parser returns test class when no namespace is used [#18]

### DIFF
--- a/test/ParaTest/Parser/ParserTest.php
+++ b/test/ParaTest/Parser/ParserTest.php
@@ -9,4 +9,18 @@ class ParserTest extends \TestBase
     {
         $parser = new Parser('/path/to/nowhere');
     }
+
+    public function testFileNameResolvesToNamespacedClass()
+    {
+        $parser = new Parser(__FILE__);
+        $class = $parser->getClass();
+        $this->assertEquals('ParaTest\Parser\ParserTest', $class->getName());
+    }
+
+    public function testFileNameResolvesToNonNamespacedClass()
+    {
+        $parser = new Parser(PARATEST_ROOT . DS . 'test' . DS . 'TestBase.php');
+        $class = $parser->getClass();
+        $this->assertEquals('TestBase', $class->getName());
+    }
 }


### PR DESCRIPTION
Allows for arbitrary class names (not following PSR-0) in test files
