### PR TITLE
$options can now be used in bootstrap

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -54,9 +54,20 @@ class PHPUnit extends Tester
     {
         $path = $input->getArgument('path');
         $options = $this->getOptions($input);
-        if(isset($options['bootstrap']) && file_exists($options['bootstrap']))
-            require_once $options['bootstrap'];
+        if(isset($options['bootstrap']) && file_exists($options['bootstrap'])) {
+            $this->requireBootstrap($options['bootstrap']);
+        }
         $options = ($path) ? array_merge(array('path' => $path), $options) : $options;
         return $options;
+    }
+
+    /**
+     * This function limits the scope affected by the bootstrap,
+     * so that $options variable defined in it doesn't break
+     * this object's configuration.
+     */
+    private function requireBootstrap($file)
+    {
+        require_once $file;
     }
 }


### PR DESCRIPTION
Without this change, defining a $options variable in the bootstrap will break Paratest.
