### PR TITLE
#27 Fixes log file path issue

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -24,7 +24,8 @@ class Reader extends MetaProvider
             throw new \InvalidArgumentException("Log file $logFile does not exist");
 
         $this->logFile = $logFile;
-        $this->xml = simplexml_load_file($this->logFile);
+		$logFileContents = file_get_contents($this->logFile);
+		$this->xml = new \SimpleXMLElement($logFileContents);
         $this->init();
     }
 

--- a/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
+++ b/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
@@ -79,7 +79,7 @@ abstract class ExecutableTest
 
     public function run($binary, $options = array())
     {
-        $options = array_merge($this->prepareOptions($options), array('log-junit' => $this->getTempFile()));
+        $options = array_merge($this->prepareOptions($options), array('log-junit' => '"' . $this->getTempFile() . '"'));
         $command = $this->getCommandString($binary, $options);
         $this->process = proc_open($command, self::$descriptors, $this->pipes);
         return $this;


### PR DESCRIPTION
- Wraps log file location in quotes when storing in options
- Separates the actual loading of the file from the `SimpleXMLElement` instantiation based on its contents.
