### PR TITLE
Improved bootstrap support

### DIFF
--- a/src/ParaTest/Console/Testers/PHPUnit.php
+++ b/src/ParaTest/Console/Testers/PHPUnit.php
@@ -5,6 +5,7 @@ use Symfony\Component\Console\Command\Command,
     Symfony\Component\Console\Input\InputArgument,
     Symfony\Component\Console\Input\InputInterface,
     Symfony\Component\Console\Output\OutputInterface,
+    ParaTest\Runners\PHPUnit\Configuration,
     ParaTest\Runners\PHPUnit\Runner;
 
 class PHPUnit extends Tester
@@ -42,20 +43,57 @@ class PHPUnit extends Tester
 
     protected function hasConfig(InputInterface $input)
     {
+        return (false !== $this->getConfig($input));
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return \ParaTest\Runners\PHPUnit\Configuration|boolean
+     */
+    protected function getConfig(InputInterface $input)
+    {
         $cwd = getcwd() . DIRECTORY_SEPARATOR;
 
         if($input->getOption('configuration'))
-            return true;
-
-        return file_exists($cwd . 'phpunit.xml.dist') || file_exists($cwd . 'phpunit.xml');
+            return $input->getOption('configuration');
+        elseif(file_exists($cwd . 'phpunit.xml.dist'))
+            return new Configuration($cwd . 'phpunit.xml.dist');
+        elseif(file_exists($cwd . 'phpunit.xml'))
+            return new Configuration($cwd . 'phpunit.xml');
+        else
+            return false;
     }
 
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return array
+     * @throws \RuntimeException
+     */
     protected function getRunnerOptions(InputInterface $input)
     {
         $path = $input->getArgument('path');
         $options = $this->getOptions($input);
-        if(isset($options['bootstrap']) && file_exists($options['bootstrap']))
-            require_once $options['bootstrap'];
+        if($this->hasConfig($input) && !isset($options['bootstrap']))
+        {
+            if($phpUnitBootstrap = $this->getConfig($input)->getBootstrap())
+            {
+                $options['bootstrap'] = $phpUnitBootstrap;
+            }
+        }
+        if(isset($options['bootstrap']))
+        {
+            if(file_exists($options['bootstrap']))
+            {
+                require_once $options['bootstrap'];
+            }
+            else
+            {
+                throw new \RuntimeException(
+                    sprintf('Bootstrap specified but could not be found (%s)',
+                        $options['bootstrap']));
+            }
+        }
+        
         $options = ($path) ? array_merge(array('path' => $path), $options) : $options;
         return $options;
     }

--- a/src/ParaTest/Runners/PHPUnit/Configuration.php
+++ b/src/ParaTest/Runners/PHPUnit/Configuration.php
@@ -12,6 +12,16 @@ class Configuration
         if(file_exists($path))
             $this->xml = simplexml_load_file($path);
     }
+    
+    /**
+     * Get the bootstrap PHPUnit configuration attribute
+     * 
+     * @return string The bootstrap attribute or empty string if not set
+     */
+    public function getBootstrap()
+    {
+        return (string)$this->xml->attributes()->bootstrap;
+    }
 
     public function getPath()
     {


### PR DESCRIPTION
Load bootstrap from PHPUnit config and throw an exception if a bootstrap is specified but cannot be found.

This addresses #28.
