### PR TITLE
descriptive error message instead of "Argument 1 passed to ParaTest\Cove...

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -320,6 +320,10 @@ class Runner
             return;
         }
 
+        if (filesize($coverageFile) == 0) {
+            throw new \RuntimeException("Coverage file $coverageFile is empty. This means a PHPUnit process has crashed.");
+        }
+
         /** @var \PHP_CodeCoverage $coverage */
         $coverage = unserialize(file_get_contents($coverageFile));
         $this->getCoverage()->addCoverage($coverage);


### PR DESCRIPTION
...rage\CoverageMerger::addCoverage() must be an instance of PHP_CodeCoverage, boolean given"
