### PR TITLE
Use Symfony's ProcessBuilder to safely build phpunit command.

### DIFF
--- a/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
+++ b/src/ParaTest/Runners/PHPUnit/ExecutableTest.php
@@ -1,6 +1,7 @@
 <?php namespace ParaTest\Runners\PHPUnit;
 
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
 
 abstract class ExecutableTest
 {
@@ -171,18 +172,28 @@ abstract class ExecutableTest
      * Returns the command string that will be executed
      * by proc_open
      *
+     * @todo Change this class to use the ProcessBuilder for everything.
      * @param $binary
      * @param array $options
      * @return mixed
      */
     protected function getCommandString($binary, $options = array())
     {
-        // TODO: this should use a CommandBuilder
-        $command = $binary;
-        foreach($options as $key => $value) $command .= " --$key %s";
-        $args = array_merge(array("$command %s %s"), array_values($options), array($this->fullyQualifiedClassName, $this->getPath()));
-        $command = call_user_func_array('sprintf', $args);
-        return $command;
+        $builder = new ProcessBuilder();
+        $builder->setPrefix($binary);
+        foreach($options as $key => $value) {
+            $builder->add("--$key");
+            if ($value !== null) {
+                $builder->add($value);
+            }
+        }
+
+        $builder->add($this->fullyQualifiedClassName);
+        $builder->add($this->getPath());
+
+        $process = $builder->getProcess();
+
+        return $process->getCommandLine();
     }
 
     /**

--- a/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
+++ b/src/ParaTest/Runners/PHPUnit/WrapperRunner.php
@@ -75,8 +75,9 @@ class WrapperRunner
 
     private function assignAllPendingTests()
     {
-        $phpunit = $this->options->phpunit . ' --no-globals-backup';
+        $phpunit = $this->options->phpunit;
         $phpunitOptions = $this->options->filtered;
+        $phpunitOptions['no-globals-backup'] = null;
         while(count($this->pending)) {
             $this->waitForStreamsToChange($this->streams);
             foreach($this->progressedWorkers() as $worker) {

--- a/test/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/ParaTest/Runners/PHPUnit/ExecutableTestTest.php
@@ -26,7 +26,7 @@ class ExecutableTestTest extends \TestBase
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
-        $this->assertEquals('/usr/bin/phpunit --bootstrap test/bootstrap.php ClassNameTest pathToFile', $command);
+        $this->assertEquals("'/usr/bin/phpunit' '--bootstrap' 'test/bootstrap.php' 'ClassNameTest' 'pathToFile'", $command);
     }
 
     public function testCommandRedirectsCoverage()
@@ -36,7 +36,7 @@ class ExecutableTestTest extends \TestBase
 
         $command = $this->executableTestChild->command($binary, $options);
         $coverageFileName = str_replace('/', '\/', $this->executableTestChild->getCoverageFileName());
-        $this->assertRegExp('/^\/usr\/bin\/phpunit --a b --coverage-php ' . $coverageFileName . ' .*/', $command);
+        $this->assertRegExp("/^'\/usr\/bin\/phpunit' '--a' 'b' '--coverage-php' '$coverageFileName' '.*'/", $command);
     }
 
     public function testGetCommandStringDoesNotIncludeEnvironmentVariablesToKeepCompatibilityWithWindows()
@@ -46,7 +46,7 @@ class ExecutableTestTest extends \TestBase
         $environmentVariables = array('APPLICATION_ENVIRONMENT_VAR' => 'abc');
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options, $environmentVariables);
 
-        $this->assertEquals('/usr/bin/phpunit --bootstrap test/bootstrap.php ClassNameTest pathToFile', $command);
+        $this->assertEquals("'/usr/bin/phpunit' '--bootstrap' 'test/bootstrap.php' 'ClassNameTest' 'pathToFile'", $command);
     }
 
     public function testGetCommandStringIncludesTheClassName()
@@ -55,7 +55,7 @@ class ExecutableTestTest extends \TestBase
         $binary = '/usr/bin/phpunit';
 
         $command = $this->call($this->executableTestChild, 'getCommandString', $binary, $options);
-        $this->assertEquals('/usr/bin/phpunit ClassNameTest pathToFile', $command);
+        $this->assertEquals("'/usr/bin/phpunit' 'ClassNameTest' 'pathToFile'", $command);
     }
 
     public function testHandleEnvironmentVariablesAssignsToken()


### PR DESCRIPTION
Spaces in the arguments (including in the filepath to the paratest
executable) were causing paratest to fail.  This uses the ProcessBuilder
to build the properly escaped command to execute.

I would like to use the process returned by the processbuilder
throughout the ExecutableTest class, but that would involve breaking the
public API of this class.  I left that as a todo for a major version
change and for the owners of the project to decide on.

This change shouldn't break things, but I don't know Windows well enough
to know if it would break due to the command being in quotes.
