### PR TITLE
PHPUnit 4.x compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ php:
     - "5.4"
     - "5.3"
 
-before_script:
-    - curl -s https://getcomposer.org/installer | php
-    - php composer.phar install --prefer-source
+env:
+    - PHPUNIT_VERSION='3.7.*'
+    - PHPUNIT_VERSION='4.0.*'
 
+before_script:
+    - composer require --no-update phpunit/phpunit=$PHPUNIT_VERSION
+    - composer install --prefer-source
 
 script:
     - vendor/bin/phpunit

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -35,7 +35,7 @@ class Reader extends MetaProvider
                                            'errors' => 0,
                                            'time' => 0);
 
-    public function __construct($logFile) 
+    public function __construct($logFile)
     {
         if(!file_exists($logFile))
             throw new \InvalidArgumentException("Log file $logFile does not exist");
@@ -190,6 +190,9 @@ class Reader extends MetaProvider
         $suiteNodes = $this->xml->xpath('/testsuites/testsuite/testsuite');
         $this->isSingle = sizeof($suiteNodes) === 0;
         $node = current($this->xml->xpath("/testsuites/testsuite"));
-        $this->suites[] = TestSuite::suiteFromNode($node);
+
+        if ($node !== false) {
+            $this->suites[] = TestSuite::suiteFromNode($node);
+        }
     }
 }

--- a/src/ParaTest/Runners/PHPUnit/Runner.php
+++ b/src/ParaTest/Runners/PHPUnit/Runner.php
@@ -324,9 +324,26 @@ class Runner
             throw new \RuntimeException("Coverage file $coverageFile is empty. This means a PHPUnit process has crashed.");
         }
 
-        /** @var \PHP_CodeCoverage $coverage */
-        $coverage = unserialize(file_get_contents($coverageFile));
-        $this->getCoverage()->addCoverage($coverage);
+        $this->getCoverage()->addCoverage($this->getCoverageObject($coverageFile));
         unlink($coverageFile);
+    }
+
+    /**
+     * Returns coverage object from file.
+     *
+     * @param string $coverageFile Coverage file.
+     *
+     * @return \PHP_CodeCoverage
+     */
+    private function getCoverageObject($coverageFile)
+    {
+        $coverage = file_get_contents($coverageFile);
+
+        if (substr($coverage, 0, 5) === '<?php') {
+            return include $coverageFile;
+        }
+
+        // the PHPUnit 3.x and below
+        return unserialize($coverage);
     }
 }

--- a/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
+++ b/src/ParaTest/Runners/PHPUnit/SuiteLoader.php
@@ -42,8 +42,10 @@ class SuiteLoader
 
     public function __construct($options = null)
     {
-        if($options && !$options instanceof Options)
+        if ($options && !$options instanceof Options) {
             throw new \InvalidArgumentException("SuiteLoader options must be null or of type Options");
+        }
+
         $this->options = $options;
     }
 
@@ -82,13 +84,26 @@ class SuiteLoader
      */
     public function load($path = '')
     {
-        $configuration = @$this->options->filtered['configuration'] ?: new Configuration('');
-        if($path) $this->loadPath($path);
-        else if($suites = $configuration->getSuites())
-            foreach($suites as $name => $dirs)
-                foreach ($dirs as $path)
+        if (is_object($this->options) && isset($this->options->filtered['configuration'])) {
+            $configuration = $this->options->filtered['configuration'];
+        } else {
+            $configuration = new Configuration('');
+        }
+
+        if ($path) {
+            $this->loadPath($path);
+        } elseif ($suites = $configuration->getSuites()) {
+            foreach ($suites as $dirs) {
+                foreach ($dirs as $path) {
                     $this->loadPath($path);
-        if(!$this->files) throw new \RuntimeException("No path or configuration provided (tests must end with Test.php)");
+                }
+            }
+        }
+
+        if (!$this->files) {
+            throw new \RuntimeException("No path or configuration provided (tests must end with Test.php)");
+        }
+
         $this->initSuites();
     }
 

--- a/test/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/ParaTest/Coverage/CoverageMergerTest.php
@@ -6,18 +6,21 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
 {
     public function testSimpleMerge()
     {
+        $firstFile = PARATEST_ROOT . '/src/ParaTest/Logging/LogInterpreter.php';
+        $secondFile = PARATEST_ROOT . '/src/ParaTest/Logging/MetaProvider.php';
+
         $coverage1 = new \PHP_CodeCoverage();
         $coverage1->append(
             array(
-                'someFile' => array(1 => 1),
-                'someOtherFile' => array(1 => 1)
+                $firstFile => array(35 => 1),
+                $secondFile => array(34 => 1)
             ),
             'Test1'
         );
         $coverage2 = new \PHP_CodeCoverage();
         $coverage2->append(
             array(
-                'someFile' => array(1 => 1, 2 => 1)
+                $firstFile => array(35 => 1, 36 => 1)
             ),
             'Test2'
         );
@@ -28,14 +31,14 @@ class CoverageMergerTest extends \PHPUnit_Framework_TestCase
         $coverage = $merger->getCoverage();
 
         $data = $coverage->getData();
-        $this->assertEquals(2, count($data['someFile'][1]));
-        $this->assertEquals('Test1', $data['someFile'][1][0]);
-        $this->assertEquals('Test2', $data['someFile'][1][1]);
+        $this->assertEquals(2, count($data[$firstFile][35]));
+        $this->assertEquals('Test1', $data[$firstFile][35][0]);
+        $this->assertEquals('Test2', $data[$firstFile][35][1]);
 
-        $this->assertEquals(1, count($data['someFile'][2]));
-        $this->assertEquals('Test2', $data['someFile'][2][0]);
+        $this->assertEquals(1, count($data[$firstFile][36]));
+        $this->assertEquals('Test2', $data[$firstFile][36][0]);
 
-        $this->assertEquals(1, count($data['someOtherFile'][1]));
-        $this->assertEquals('Test1', $data['someOtherFile'][1][0]);
+        $this->assertEquals(1, count($data[$secondFile][34]));
+        $this->assertEquals('Test1', $data[$secondFile][34][0]);
     }
 }

--- a/test/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/ParaTest/Runners/PHPUnit/SuiteLoaderTest.php
@@ -2,6 +2,9 @@
 
 class SuiteLoaderTest extends \TestBase
 {
+    /**
+     * @var SuiteLoader
+     */
     protected $loader;
     protected $files;
     protected $options;
@@ -48,7 +51,7 @@ class SuiteLoaderTest extends \TestBase
      */
     public function testOptionsMustBeInstanceOfOptionsIfNotNull()
     {
-        $loader = new SuiteLoader(array('one' => 'two', 'three' => 'foure'));        
+        $loader = new SuiteLoader(array('one' => 'two', 'three' => 'foure'));
     }
 
     /**


### PR DESCRIPTION
Updates paratest code to allow using either PHPUnit 3.x (or below) or latest PHPUnit 4.x versions.

Most likely will solve both #83 and #79 once finished.
