### PR TITLE
Paratest Test Suite: Skip tests that require code coverage if no driver exists.

### DIFF
--- a/it/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
+++ b/it/ParaTest/Runners/PHPUnit/RunnerIntegrationTest.php
@@ -7,6 +7,12 @@ class RunnerIntegrationTest extends \TestBase
 
     public function setUp()
     {
+        try {
+            $coverage = new \PHP_CodeCoverage();
+        } catch(\Exception $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+
         $this->options = array(
             'path' => FIXTURES . DS . 'tests',
             'phpunit' => PHPUNIT,

--- a/test/ParaTest/Coverage/CoverageMergerTest.php
+++ b/test/ParaTest/Coverage/CoverageMergerTest.php
@@ -4,6 +4,15 @@ namespace ParaTest\Coverage;
 
 class CoverageMergerTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        try {
+            $coverage = new \PHP_CodeCoverage();
+        } catch(\Exception $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+    }
+
     public function testSimpleMerge()
     {
         $firstFile = PARATEST_ROOT . '/src/ParaTest/Logging/LogInterpreter.php';


### PR DESCRIPTION
This fixes #106 
