### PR TITLE
Fix broken autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "autoload": {
         "psr-0": {
             "": ["test/unit", "test/functional"],
-            "ParaTest": ["src/"]
+            "ParaTest": ["src/", "test/unit", "test/functional"]
         }
     }
 }


### PR DESCRIPTION
The unit tests depend on loading ParaTest classes under test/unit. 
