### PR TITLE
add scrutinizer ci support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,29 @@
+filter:
+  paths: [src/*]
+  excluded_paths: [vendor/*, tests/*]
+checks:
+  php:
+    parameter_doc_comments: false
+tools:
+  php_cpd: true
+  php_changetracking: true
+  php_mess_detector:
+    enabled: true
+    config:
+      design_rules:
+        exit_expression: false
+  php_pdepend: true
+  php_analyzer:
+    enabled: true
+    config:
+      doc_comment_fixes:
+        enabled: false
+      verify_php_doc_comments:
+        enabled: false
+      method_contract_checks:
+        verify_documented_constraints: false
+  sensiolabs_security_checker: true
+  php_code_sniffer: 
+    enabled: true
+    config:
+      standard: "PSR2"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ParaTest
 ========
 [![Build Status](https://secure.travis-ci.org/brianium/paratest.png?branch=master)](https://travis-ci.org/brianium/paratest)
 [![HHVM Status](http://hhvm.h4cc.de/badge/brianium/paratest.svg)](http://hhvm.h4cc.de/package/brianium/paratest)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/brianium/paratest/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/brianium/paratest/?branch=master)
 
 The objective of ParaTest is to support parallel testing in a variety of PHP testing tools. Currently only PHPUnit is supported.
 


### PR DESCRIPTION
Adds support for scrutinizer-ci to paratest. Opts for php_cpd over scrutinizer's php_sim. I have noticed that cpd is more mature and sane about what is considered duplicated code, especially when it comes to things like __call and __get.

Any future tweaks to what we want to track can be added to .scrutinizer.yml

fixes #120 
