### PR TITLE
Fix handling of '&' symbols in JUnit XML

### DIFF
--- a/src/ParaTest/Logging/JUnit/Writer.php
+++ b/src/ParaTest/Logging/JUnit/Writer.php
@@ -147,7 +147,7 @@ class Writer
     protected function appendDefects($caseNode, $defects, $type)
     {
         foreach($defects as $defect) {
-            $defectNode = $this->document->createElement($type, $defect['text'] . "\n");
+            $defectNode = $this->document->createElement($type, htmlentities($defect['text']) . "\n");
             $defectNode->setAttribute('type', $defect['type']);
             $caseNode->appendChild($defectNode);
         }


### PR DESCRIPTION
Without this change whenever  URLs with '&' symbol appears in phpunit output, it triggers warning and URL is corrupted in Jenkins.

Example URL:
http://test.site.com?key=1419318842&ip=0i1BxHBaShQueFNYFQaA3IbyAJC3HncWngeY2hZdEy3bSTFOkeXUzbusMUyiisAPAgoc50Ms-wuTS_rWwUHLvPNzFchl8ebXm3ljF83mfzxX98SaPLzWtoyMQauIwHWqKknjtRxRI1flde3ovN7kdQ&im=image/png&o=&cd=inline

Error in console:
 [exec] #2 /var/www/optimalprint-trunk/internal/SL/Test/Functional/Page/Category/CategoryDesktopPHP Warning:  DOMDocument::createElement(): unterminated entity reference ip=0i1BxHBaShQueFNYFQaA3IbyAJC3HncWngeY2hZdEy3bSTFOkeXUzbusMUyiisAPAgoc50Ms-wuTS_rWwUHLvPNzFchl8ebXm3ljF83mfzxX98SaPLzWtoyMQauIwHWqKknjtRxRI1flde3ovN7kdQ&im=image/png&o=&cd=inline
