### PR TITLE
Adds error messaging to Parser when a class cannot be found.

### DIFF
--- a/src/ParaTest/Parser/Parser.php
+++ b/src/ParaTest/Parser/Parser.php
@@ -32,13 +32,17 @@ class Parser
     public function __construct($srcPath)
     {
         if(!file_exists($srcPath))
-            throw new \InvalidArgumentException("file not found");
+            throw new \InvalidArgumentException("file not found: " . $srcPath);
 
         $this->path = $srcPath;
         $declaredClasses = get_declared_classes();
         require_once($this->path);
         $class = $this->getClassName($this->path, $declaredClasses);
-        $this->refl = new \ReflectionClass($class);
+        try{
+            $this->refl = new \ReflectionClass($class);
+        } catch (\ReflectionException $e){
+            throw new \InvalidArgumentException("Unable to instantiate ReflectionClass. " . $class . " not found in: " . $srcPath);
+        }
     }
 
     /**

--- a/test/unit/ParaTest/Parser/ParserTest.php
+++ b/test/unit/ParaTest/Parser/ParserTest.php
@@ -9,4 +9,13 @@ class ParserTest extends \TestBase
     {
         $parser = new Parser('/path/to/nowhere');
     }
+
+    /**
+     * @expectedException  \InvalidArgumentException
+     */
+    public function testConstructorThrowsExceptionIfClassNotFoundInFile()
+    {
+        $fileWithoutAClass = FIXTURES . DS . 'chdirBootstrap.php';
+        $parser = new Parser($fileWithoutAClass);
+    }
 }


### PR DESCRIPTION
When attempting to implement paratest into our code base, I was presented with the following:

![screen shot 2014-12-30 at 9 25 38 am](https://cloud.githubusercontent.com/assets/1444395/5580863/dd1ab978-9005-11e4-831a-c72e6acfc16b.png)

This pull request adds more specific messaging when a class does not exist in the provided srcPath.
