### PR TITLE
Add option coverage-text

### DIFF
--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -46,6 +46,7 @@ class ParaTestCommand extends Command
             ->addOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.')
             ->addOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.')
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
+            ->addOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).');
 

--- a/src/Console/Testers/PHPUnit.php
+++ b/src/Console/Testers/PHPUnit.php
@@ -207,9 +207,10 @@ class PHPUnit extends Tester
     protected function hasCoverage(array $options): bool
     {
         $isFileFormat = isset($options['coverage-html']) || isset($options['coverage-clover']);
+        $isTextFormat = isset($options['coverage-text']);
         $isPHP = isset($options['coverage-php']);
 
-        return $isFileFormat && !$isPHP;
+        return $isTextFormat || $isFileFormat && !$isPHP;
     }
 
     /**

--- a/src/Coverage/CoverageReporter.php
+++ b/src/Coverage/CoverageReporter.php
@@ -8,6 +8,7 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Report\Clover;
 use SebastianBergmann\CodeCoverage\Report\Html;
 use SebastianBergmann\CodeCoverage\Report\PHP;
+use SebastianBergmann\CodeCoverage\Report\Text;
 
 class CoverageReporter implements CoverageReporterInterface
 {
@@ -55,5 +56,14 @@ class CoverageReporter implements CoverageReporterInterface
     {
         $php = new PHP();
         $php->process($this->coverage, $target);
+    }
+
+    /**
+     * Generate text coverage report.
+     */
+    public function text()
+    {
+        $text = new Text();
+        echo $text->process($this->coverage);
     }
 }

--- a/src/Coverage/CoverageReporterInterface.php
+++ b/src/Coverage/CoverageReporterInterface.php
@@ -26,4 +26,9 @@ interface CoverageReporterInterface
      * @param string $target Report filename
      */
     public function php(string $target);
+
+    /**
+     * Generate text coverage report.
+     */
+    public function text();
 }

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -147,6 +147,9 @@ abstract class BaseRunner
         if (isset($filteredOptions['coverage-html'])) {
             $reporter->html($filteredOptions['coverage-html']);
         }
+        if (isset($filteredOptions['coverage-text'])) {
+            $reporter->text();
+        }
 
         $reporter->php($filteredOptions['coverage-php']);
     }
@@ -156,7 +159,6 @@ abstract class BaseRunner
         if (!isset($this->options->filtered['coverage-php'])) {
             return;
         }
-
         $this->coverage = new CoverageMerger();
     }
 

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -354,7 +354,7 @@ abstract class ExecutableTest
             $options['coverage-php'] = $this->getCoverageFileName();
         }
 
-        unset($options['coverage-html'], $options['coverage-clover']);
+        unset($options['coverage-html'], $options['coverage-clover'], $options['coverage-text']);
 
         return $options;
     }

--- a/test/unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/Console/Commands/ParaTestCommandTest.php
@@ -54,6 +54,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.'),
             new InputOption('coverage-html', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in HTML format.'),
             new InputOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.'),
+            new InputOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),


### PR DESCRIPTION
This PR makes paratest support PhpUnit's --coverage-text option.

related issue: https://github.com/paratestphp/paratest/issues/231