### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/test/functional/PHPUnitTest.php
+++ b/test/functional/PHPUnitTest.php
@@ -239,7 +239,7 @@ class PHPUnitTest extends FunctionalTestBase
         $proc = $this->invokeParatest('fatal-tests/UnitTestWithFatalParseErrorTest.php', [
             'bootstrap' => BOOTSTRAP,
         ]);
-        $this->assertTrue(in_array($proc->getExitCode(), [1, 255], true));
+        $this->assertContains($proc->getExitCode(), [1, 255]);
     }
 
     public function testStopOnFailurePreventsStartingFurtherTestsAfterFailure()

--- a/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
+++ b/test/functional/ParaTest/Runners/PHPUnit/WorkerTest.php
@@ -161,6 +161,6 @@ class WorkerTest extends \TestBase
         $this->assertFileExists($logFile, "Failed asserting that $logFile exists.");
         $log = new SimpleXMLElement(file_get_contents($logFile));
         $count = count($log->testsuite->testcase);
-        $this->assertTrue($count > 1, 'Not even a test has been executed');
+        $this->assertGreaterThan(1, $count, 'Not even a test has been executed');
     }
 }

--- a/test/functional/SkippedOrIncompleteTest.php
+++ b/test/functional/SkippedOrIncompleteTest.php
@@ -120,7 +120,7 @@ class SkippedOrIncompleteTest extends FunctionalTestBase
     protected function assertContainsNSkippedTests($n, $output)
     {
         preg_match('/\n\n([\.ISEF].*)\n\nTime/s', $output, $matches);
-        $this->assertEquals(2, count($matches));
+        $this->assertCount(2, $matches);
         $numberOfS = substr_count($matches[1], 'S');
         $this->assertEquals($n, $numberOfS, "The test should have skipped $n tests, instead it skipped $numberOfS, $matches[1]");
     }

--- a/test/unit/Logging/JUnit/ReaderTest.php
+++ b/test/unit/Logging/JUnit/ReaderTest.php
@@ -44,7 +44,7 @@ class ReaderTest extends \TestBase
     public function testMixedSuiteShouldConstructRootSuite()
     {
         $suites = $this->mixed->getSuites();
-        $this->assertEquals(1, count($suites));
+        $this->assertCount(1, $suites);
         $this->assertEquals('test/fixtures/tests/', $suites[0]->name);
         $this->assertEquals('7', $suites[0]->tests);
         $this->assertEquals('6', $suites[0]->assertions);
@@ -62,7 +62,7 @@ class ReaderTest extends \TestBase
      */
     public function testMixedSuiteConstructsChildSuites($suite)
     {
-        $this->assertEquals(3, count($suite->suites));
+        $this->assertCount(3, $suite->suites);
         $first = $suite->suites[0];
         $this->assertEquals('UnitTestWithClassAnnotationTest', $first->name);
         $this->assertEquals('/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php', $first->file);
@@ -82,7 +82,7 @@ class ReaderTest extends \TestBase
      */
     public function testMixedSuiteConstructsTestCases($suite)
     {
-        $this->assertEquals(3, count($suite->cases));
+        $this->assertCount(3, $suite->cases);
         $first = $suite->cases[0];
         $this->assertEquals('testTruth', $first->name);
         $this->assertEquals('UnitTestWithClassAnnotationTest', $first->class);
@@ -96,7 +96,7 @@ class ReaderTest extends \TestBase
     {
         $suites = $this->mixed->getSuites();
         $case = $suites[0]->suites[0]->cases[1];
-        $this->assertEquals(1, count($case->failures));
+        $this->assertCount(1, $case->failures);
         $failure = $case->failures[0];
         $this->assertEquals(ExpectationFailedException::class, $failure['type']);
         $this->assertEquals("UnitTestWithClassAnnotationTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20", $failure['text']);
@@ -106,7 +106,7 @@ class ReaderTest extends \TestBase
     {
         $suites = $this->mixed->getSuites();
         $case = $suites[0]->suites[1]->cases[0];
-        $this->assertEquals(1, count($case->errors));
+        $this->assertCount(1, $case->errors);
         $error = $case->errors[0];
         $this->assertEquals('Exception', $error['type']);
         $this->assertEquals("UnitTestWithErrorTest::testTruth\nException: Error!!!\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php:12", $error['text']);
@@ -115,7 +115,7 @@ class ReaderTest extends \TestBase
     public function testSingleSuiteShouldConstructRootSuite()
     {
         $suites = $this->single->getSuites();
-        $this->assertEquals(1, count($suites));
+        $this->assertCount(1, $suites);
         $this->assertEquals('UnitTestWithMethodAnnotationsTest', $suites[0]->name);
         $this->assertEquals('/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php', $suites[0]->file);
         $this->assertEquals('3', $suites[0]->tests);
@@ -134,7 +134,7 @@ class ReaderTest extends \TestBase
      */
     public function testSingleSuiteShouldHaveNoChildSuites($suite)
     {
-        $this->assertEquals(0, count($suite->suites));
+        $this->assertCount(0, $suite->suites);
     }
 
     /**
@@ -144,7 +144,7 @@ class ReaderTest extends \TestBase
      */
     public function testSingleSuiteConstructsTestCases($suite)
     {
-        $this->assertEquals(3, count($suite->cases));
+        $this->assertCount(3, $suite->cases);
         $first = $suite->cases[0];
         $this->assertEquals('testTruth', $first->name);
         $this->assertEquals('UnitTestWithMethodAnnotationsTest', $first->class);
@@ -158,7 +158,7 @@ class ReaderTest extends \TestBase
     {
         $suites = $this->single->getSuites();
         $case = $suites[0]->cases[1];
-        $this->assertEquals(1, count($case->failures));
+        $this->assertCount(1, $case->failures);
         $failure = $case->failures[0];
         $this->assertEquals(ExpectationFailedException::class, $failure['type']);
         $this->assertEquals("UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18", $failure['text']);
@@ -167,7 +167,7 @@ class ReaderTest extends \TestBase
     public function testEmptySuiteConstructsTestCase()
     {
         $suites = $this->empty->getSuites();
-        $this->assertEquals(1, count($suites));
+        $this->assertCount(1, $suites);
 
         $suite = $suites[0];
         $this->assertEquals('', $suite->name);
@@ -200,7 +200,7 @@ class ReaderTest extends \TestBase
     public function testMixedGetFailureMessages()
     {
         $failures = $this->mixed->getFailures();
-        $this->assertEquals(2, count($failures));
+        $this->assertCount(2, $failures);
         $this->assertEquals("UnitTestWithClassAnnotationTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithClassAnnotationTest.php:20", $failures[0]);
         $this->assertEquals("UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18", $failures[1]);
     }
@@ -208,14 +208,14 @@ class ReaderTest extends \TestBase
     public function testMixedGetErrorMessages()
     {
         $errors = $this->mixed->getErrors();
-        $this->assertEquals(1, count($errors));
+        $this->assertCount(1, $errors);
         $this->assertEquals("UnitTestWithErrorTest::testTruth\nException: Error!!!\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithErrorTest.php:12", $errors[0]);
     }
 
     public function testSingleGetMessages()
     {
         $failures = $this->single->getFailures();
-        $this->assertEquals(1, count($failures));
+        $this->assertCount(1, $failures);
         $this->assertEquals("UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18", $failures[0]);
     }
 

--- a/test/unit/Logging/JUnit/WriterTest.php
+++ b/test/unit/Logging/JUnit/WriterTest.php
@@ -86,6 +86,6 @@ class WriterTest extends \TestBase
         $writer = new Writer($this->interpreter, 'test/fixtures/tests/');
         $xml = $writer->getXml();
 
-        $this->assertFalse(strpos($xml, 'line=""'), 'Expected no empty line attributes (line=""), but found one.');
+        $this->assertNotContains('line=""', $xml, 'Expected no empty line attributes (line=""), but found one.');
     }
 }

--- a/test/unit/Logging/LogInterpreterTest.php
+++ b/test/unit/Logging/LogInterpreterTest.php
@@ -30,7 +30,7 @@ class LogInterpreterTest extends ResultTester
     {
         $reader = $this->getMockReader();
         $this->interpreter->addReader($reader);
-        $this->assertEquals(3, count($this->getObjectValue($this->interpreter, 'readers')));
+        $this->assertCount(3, $this->getObjectValue($this->interpreter, 'readers'));
     }
 
     public function testAddReaderReturnsSelf()
@@ -45,7 +45,7 @@ class LogInterpreterTest extends ResultTester
         $reader = $this->getMockReader();
         $this->interpreter->addReader($reader);
         $readers = $this->interpreter->getReaders();
-        $this->assertEquals(3, count($readers));
+        $this->assertCount(3, $readers);
         $last = array_pop($readers);
         $this->assertSame($reader, $last);
     }
@@ -115,7 +115,7 @@ class LogInterpreterTest extends ResultTester
     public function testGetCasesReturnsAllCases()
     {
         $cases = $this->interpreter->getCases();
-        $this->assertEquals(10, count($cases));
+        $this->assertCount(10, $cases);
     }
 
     public function testGetCasesExtendEmptyCasesFromSuites()
@@ -124,7 +124,7 @@ class LogInterpreterTest extends ResultTester
         $dataProviderReader = $this->getReader('dataProviderSuite');
         $interpreter->addReader($dataProviderReader);
         $cases = $interpreter->getCases();
-        $this->assertEquals(10, count($cases));
+        $this->assertCount(10, $cases);
         foreach ($cases as $name => $case) {
             $this->assertAttributeNotEmpty('class', $case);
             $this->assertAttributeNotEmpty('file', $case);
@@ -148,7 +148,7 @@ class LogInterpreterTest extends ResultTester
     public function testFlattenCasesReturnsCorrectNumberOfSuites()
     {
         $suites = $this->interpreter->flattenCases();
-        $this->assertEquals(4, count($suites));
+        $this->assertCount(4, $suites);
 
         return $suites;
     }

--- a/test/unit/Parser/ParsedClassTest.php
+++ b/test/unit/Parser/ParsedClassTest.php
@@ -62,7 +62,7 @@ class ParsedClassTest extends \TestBase
     public function testGetMethodsExceptsAdditionalAnnotationFilter()
     {
         $group1 = $this->class->getMethods(['group' => 'group1']);
-        $this->assertEquals(1, count($group1));
+        $this->assertCount(1, $group1);
         $this->assertEquals($this->methods[0], $group1[0]);
     }
 }

--- a/test/unit/Parser/ParserTest/GetClassTest.php
+++ b/test/unit/Parser/ParserTest/GetClassTest.php
@@ -45,13 +45,13 @@ class GetClassTest extends \TestBase
     public function testParsedClassHasCorrectNumberOfTestMethods()
     {
         $class = $this->parseFile($this->fixture('failing-tests/UnitTestWithClassAnnotationTest.php'));
-        $this->assertEquals(4, count($class->getMethods()));
+        $this->assertCount(4, $class->getMethods());
     }
 
     public function testParsedClassWithParentHasCorrectNumberOfTestMethods()
     {
         $class = $this->parseFile($this->fixture('failing-tests/UnitTestWithErrorTest.php'));
-        $this->assertEquals(4, count($class->getMethods()));
+        $this->assertCount(4, $class->getMethods());
     }
 
     /**

--- a/test/unit/Runners/PHPUnit/ConfigurationTest.php
+++ b/test/unit/Runners/PHPUnit/ConfigurationTest.php
@@ -23,7 +23,7 @@ class ConfigurationTest extends \TestBase
     public function test_getSuitesShouldReturnCorrectNumberOfSuites()
     {
         $suites = $this->config->getSuites();
-        $this->assertEquals(2, count($suites));
+        $this->assertCount(2, $suites);
 
         return $suites;
     }

--- a/test/unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/Runners/PHPUnit/OptionsTest.php
@@ -31,7 +31,7 @@ class OptionsTest extends \TestBase
 
     public function testAnnotationsReturnsAnnotations()
     {
-        $this->assertEquals(1, count($this->options->annotations));
+        $this->assertCount(1, $this->options->annotations);
         $this->assertEquals('group1', $this->options->annotations['group']);
     }
 

--- a/test/unit/Runners/PHPUnit/RunnerTest.php
+++ b/test/unit/Runners/PHPUnit/RunnerTest.php
@@ -46,7 +46,7 @@ class RunnerTest extends \TestBase
         $opts = ['processes' => 4, 'path' => FIXTURES . DS . 'tests', 'bootstrap' => 'hello', 'functional' => true];
         $runner = new Runner($opts);
         $tokens = $this->getObjectValue($runner, 'tokens');
-        $this->assertEquals(4, count($tokens));
+        $this->assertCount(4, $tokens);
     }
 
     public function testGetsNextAvailableTokenReturnsTokenIdentifier()
@@ -78,7 +78,7 @@ class RunnerTest extends \TestBase
         $this->setObjectValue($runner, 'tokens', $tokens);
 
         $tokenData = $this->call($runner, 'getNextAvailableToken');
-        $this->assertTrue($tokenData === false);
+        $this->assertFalse($tokenData);
     }
 
     public function testReleaseTokenMakesTokenAvailable()

--- a/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
@@ -48,7 +48,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = 1;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteFilesFromConfigWhileIgnoringExcludeTag()
@@ -61,7 +61,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = 1;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteFilesFromDirFromConfigWhileRespectingExcludeTag()
@@ -74,7 +74,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = 2;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteFilesFromConfigWhileIncludingAndExcludingTheSameDirectory()
@@ -87,7 +87,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = 1;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteFilesFromConfig()
@@ -100,7 +100,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = 2;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteWithDirectory()
@@ -111,7 +111,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests'));
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteWithDirectories()
@@ -123,7 +123,7 @@ class SuiteLoaderTest extends \TestBase
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests')) +
             count($this->findTests(FIXTURES . DS . 'failing-tests'));
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteWithFilesDirsMixed()
@@ -136,7 +136,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = count($this->findTests(FIXTURES . DS . 'failing-tests')) + 2;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteWithNestedSuite()
@@ -150,7 +150,7 @@ class SuiteLoaderTest extends \TestBase
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests')) +
             count($this->findTests(FIXTURES . DS . 'failing-tests')) + 1;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadTestsuiteWithDuplicateFilesDirMixed()
@@ -161,7 +161,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests')) + 1;
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadSuiteFromConfig()
@@ -172,7 +172,7 @@ class SuiteLoaderTest extends \TestBase
         $files = $this->getObjectValue($loader, 'files');
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests'));
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     public function testLoadSuiteFromConfigWithMultipleDirs()
@@ -184,7 +184,7 @@ class SuiteLoaderTest extends \TestBase
 
         $expected = count($this->findTests(FIXTURES . DS . 'passing-tests')) +
             count($this->findTests(FIXTURES . DS . 'failing-tests'));
-        $this->assertEquals($expected, count($files));
+        $this->assertCount($expected, $files);
     }
 
     /**
@@ -246,7 +246,7 @@ class SuiteLoaderTest extends \TestBase
     {
         $first = $this->suiteByPath('GroupsTest.php', $paraSuites);
         $functions = $first->getFunctions();
-        $this->assertEquals(5, count($functions));
+        $this->assertCount(5, $functions);
         $this->assertEquals('testTruth', $functions[0]->getName());
         $this->assertEquals('testFalsehood', $functions[1]->getName());
         $this->assertEquals('testArrayLength', $functions[2]->getName());
@@ -273,7 +273,7 @@ class SuiteLoaderTest extends \TestBase
     {
         $second = $this->suiteByPath('LegacyNamespaceTest.php', $paraSuites);
         $functions = $second->getFunctions();
-        $this->assertEquals(1, count($functions));
+        $this->assertCount(1, $functions);
     }
 
     public function testGetTestMethodsOnlyReturnsMethodsOfGroupIfOptionIsSpecified()
@@ -283,7 +283,7 @@ class SuiteLoaderTest extends \TestBase
         $groupsTest = $this->fixture('passing-tests/GroupsTest.php');
         $loader->load($groupsTest);
         $methods = $loader->getTestMethods();
-        $this->assertEquals(2, count($methods));
+        $this->assertCount(2, $methods);
         $this->assertEquals('testTruth', $methods[0]->getName());
         $this->assertEquals('testFalsehood', $methods[1]->getName());
     }
@@ -293,7 +293,7 @@ class SuiteLoaderTest extends \TestBase
         $loader = new SuiteLoader();
         $fileWithoutClass = $this->fixture('special-classes/FileWithoutClass.php');
         $loader->load($fileWithoutClass);
-        $this->assertSame(0, count($loader->getTestMethods()));
+        $this->assertCount(0, $loader->getTestMethods());
     }
 
     public function testExecutableTestsForFunctionalModeUse()
@@ -302,7 +302,7 @@ class SuiteLoaderTest extends \TestBase
         $loader = new SuiteLoader();
         $loader->load($path);
         $tests = $loader->getTestMethods();
-        $this->assertEquals(2, count($tests));
+        $this->assertCount(2, $tests);
         $testMethod = $tests[0];
         $this->assertEquals($testMethod->getName(), 'testOneA|testOneBDependsOnA|testOneCDependsOnB');
         $testMethod = $tests[1];


### PR DESCRIPTION
Using PHPUnit dedicated assertions will give us better error messages, making easier to debug fails. For example:
```diff
-$this->assertTrue(in_array('foo', ['bar', 'baz']));
+$this->assertContains('foo', ['baz', 'bar']);
```

Will give us:
```diff
-Failed asserting that false is true.
+Failed asserting that an array contains 'foo'.
```