### PR TITLE
Publish Phar executable on Release pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env:
         - DEPS=lowest
     - php: 7.1
+      env:
+        - BUILD_PHAR=true
     - php: 7.1
       env:
         - PHPUNIT_DEV=true
@@ -38,6 +40,7 @@ script:
 
 after_script:
   - if [[ $CODE_COVERAGE == 'true' ]]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi;
+  - if [[ $BUILD_PHAR == 'true' ]]; then curl -LSs https://box-project.github.io/box2/installer.php | php; php -d phar.readonly=0 box.phar build -c box.json.dist; fi;
 
 notifications:
   email: false

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,27 @@
+{
+    "alias": "paratest.phar",
+    "chmod": "0755",
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Json",
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "directories": [
+        "src"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+                "friendsofphp"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "files": [
+        "LICENSE"
+    ],
+    "git-version": "git-version",
+    "main": "bin/paratest",
+    "output": "paratest-@git-version@.phar",
+    "stub": true
+}


### PR DESCRIPTION
To resolve #176, The Phar executable is very useful when root project has some dependency conflict with paratest, for example `symfony/console`.

This PR require Github token to work properly, You can replace APIKEY by editing files (**"Allow edits from maintainers has checked"**), It should work like following link.
https://github.com/Gasol/paratest/releases/tag/2.0.0

See also  https://docs.travis-ci.com/user/deployment/releases/#Authenticating-with-an-OAuth-token and https://github.com/travis-ci/travis-ci/issues/2457#issuecomment-47113151
