### PR TITLE
#320 fixed - tag name 2.0 didn't match the regex pattern, adjusted pattern

### DIFF
--- a/test/unit/Console/VersionProviderTest.php
+++ b/test/unit/Console/VersionProviderTest.php
@@ -43,6 +43,6 @@ class VersionProviderTest extends TestCase
         $provider = new VersionProvider();
         $actual = $provider->getGitVersion();
         $this->assertInternalType('string', $actual, 'Git is enabled and works');
-        $this->assertRegExp("~^\d.\d.\d+(?:-\d+-g[\da-f]+)?$~", $actual, 'Git gives a version');
+        $this->assertRegExp("~^\d.\d(?:.\d+)?(?:-\d+-g[\da-f]+)?$~", $actual, 'Git gives a version');
     }
 }


### PR DESCRIPTION
fixes #320 - version tag 2.0 broke the pattern, thrid component is now optional