### PR TITLE
#324 fixed - derivation of phpunit runner pointing to php instead of binary

### DIFF
--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -6,7 +6,6 @@ namespace ParaTest\Runners\PHPUnit;
 
 /**
  * Class Options.
- *
  * An object containing all configurable information used
  * to run PHPUnit via ParaTest
  */
@@ -123,7 +122,7 @@ class Options
         $this->noTestTokens = $opts['no-test-tokens'];
         $this->colors = $opts['colors'];
         $this->testsuite = $opts['testsuite'];
-        $this->maxBatchSize = (int) $opts['max-batch-size'];
+        $this->maxBatchSize = (int)$opts['max-batch-size'];
         $this->filter = $opts['filter'];
 
         // we need to register that options if they are blank but do not get them as
@@ -132,11 +131,11 @@ class Options
         // and it's wrong because group and exclude-group options require value when passed
         // to phpunit)
         $this->groups = isset($opts['group']) && $opts['group'] !== ''
-                      ? explode(',', $opts['group'])
-                      : [];
+            ? explode(',', $opts['group'])
+            : [];
         $this->excludeGroups = isset($opts['exclude-group']) && $opts['exclude-group'] !== ''
-                             ? explode(',', $opts['exclude-group'])
-                             : [];
+            ? explode(',', $opts['exclude-group'])
+            : [];
 
         if (isset($opts['filter']) && strlen($opts['filter']) > 0 && !$this->functional) {
             throw new \RuntimeException('Option --filter is not implemented for non functional mode');
@@ -144,6 +143,64 @@ class Options
 
         $this->filtered = $this->filterOptions($opts);
         $this->initAnnotations();
+    }
+
+    /**
+     * Returns a collection of ParaTest's default
+     * option values.
+     *
+     * @return array
+     */
+    protected static function defaults(): array
+    {
+        return [
+            'processes'       => 5,
+            'path'            => '',
+            'phpunit'         => static::phpunit(),
+            'functional'      => false,
+            'stop-on-failure' => false,
+            'runner'          => 'Runner',
+            'no-test-tokens'  => false,
+            'colors'          => false,
+            'testsuite'       => '',
+            'max-batch-size'  => 0,
+            'filter'          => null,
+        ];
+    }
+
+    /**
+     * Get the path to phpunit
+     * First checks if a Windows batch script is in the composer vendors directory.
+     * Composer automatically handles creating a .bat file, so if on windows this should be the case.
+     * Second look for the phpunit binary under nix
+     * Defaults to phpunit on the users PATH.
+     *
+     * @return string $phpunit the path to phpunit
+     */
+    protected static function phpunit(): string
+    {
+        $vendor = static::vendorDir();
+        $phpunit = $vendor . DIRECTORY_SEPARATOR . 'phpunit' . DIRECTORY_SEPARATOR . 'phpunit' . DIRECTORY_SEPARATOR . 'phpunit';
+        if (file_exists($phpunit)) {
+            return $phpunit;
+        }
+
+        return 'phpunit';
+    }
+
+    /**
+     * Get the path to the vendor directory
+     * First assumes vendor directory is accessible from src (i.e development)
+     * Second assumes vendor directory is accessible within src.
+     */
+    protected static function vendorDir(): string
+    {
+        $vendor = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'vendor';
+        if (!file_exists($vendor)) {
+            $vendor = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+        }
+
+        return $vendor;
     }
 
     /**
@@ -172,86 +229,23 @@ class Options
     }
 
     /**
-     * Returns a collection of ParaTest's default
-     * option values.
-     *
-     * @return array
-     */
-    protected static function defaults(): array
-    {
-        return [
-            'processes' => 5,
-            'path' => '',
-            'phpunit' => static::phpunit(),
-            'functional' => false,
-            'stop-on-failure' => false,
-            'runner' => 'Runner',
-            'no-test-tokens' => false,
-            'colors' => false,
-            'testsuite' => '',
-            'max-batch-size' => 0,
-            'filter' => null,
-        ];
-    }
-
-    /**
-     * Get the path to phpunit
-     * First checks if a Windows batch script is in the composer vendors directory.
-     * Composer automatically handles creating a .bat file, so if on windows this should be the case.
-     * Second look for the phpunit binary under nix
-     * Defaults to phpunit on the users PATH.
-     *
-     * @return string $phpunit the path to phpunit
-     */
-    protected static function phpunit(): string
-    {
-        $vendor = static::vendorDir();
-
-        $phpunit = $vendor . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpunit';
-        $batch = $phpunit . '.bat';
-
-        if (DIRECTORY_SEPARATOR === '\\' && file_exists($batch)) {
-            return $phpunit . '.bat';
-        } elseif (file_exists($phpunit)) {
-            return $phpunit;
-        }
-
-        return 'phpunit';
-    }
-
-    /**
-     * Get the path to the vendor directory
-     * First assumes vendor directory is accessible from src (i.e development)
-     * Second assumes vendor directory is accessible within src.
-     */
-    protected static function vendorDir(): string
-    {
-        $vendor = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'vendor';
-        if (!file_exists($vendor)) {
-            $vendor = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
-        }
-
-        return $vendor;
-    }
-
-    /**
      * Filter options to distinguish between paratest
      * internal options and any other options.
      */
     protected function filterOptions(array $options): array
     {
         $filtered = array_diff_key($options, [
-            'processes' => $this->processes,
-            'path' => $this->path,
-            'phpunit' => $this->phpunit,
-            'functional' => $this->functional,
+            'processes'       => $this->processes,
+            'path'            => $this->path,
+            'phpunit'         => $this->phpunit,
+            'functional'      => $this->functional,
             'stop-on-failure' => $this->stopOnFailure,
-            'runner' => $this->runner,
-            'no-test-tokens' => $this->noTestTokens,
-            'colors' => $this->colors,
-            'testsuite' => $this->testsuite,
-            'max-batch-size' => $this->maxBatchSize,
-            'filter' => $this->filter,
+            'runner'          => $this->runner,
+            'no-test-tokens'  => $this->noTestTokens,
+            'colors'          => $this->colors,
+            'testsuite'       => $this->testsuite,
+            'max-batch-size'  => $this->maxBatchSize,
+            'filter'          => $this->filter,
         ]);
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);
@@ -278,33 +272,6 @@ class Options
     }
 
     /**
-     * Retrieve the default configuration given a path (directory or file).
-     * This will search into the directory, if a directory is specified.
-     *
-     * @param string $path    The path to search into
-     * @param string $default The default value to give back
-     *
-     * @return string|null
-     */
-    private function getDefaultConfigurationForPath(string $path = '.', string $default = null)
-    {
-        if ($this->isFile($path)) {
-            return realpath($path);
-        }
-
-        $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        $suffixes = ['phpunit.xml', 'phpunit.xml.dist'];
-
-        foreach ($suffixes as $suffix) {
-            if ($this->isFile($path . $suffix)) {
-                return realpath($path . $suffix);
-            }
-        }
-
-        return $default;
-    }
-
-    /**
      * Load options that are represented by annotations
      * inside of tests i.e @group group1 = --group group1.
      */
@@ -316,6 +283,37 @@ class Options
                 $this->annotations[$key] = $value;
             }
         }
+    }
+
+    /**
+     * Retrieve the default configuration given a path (directory or file).
+     * This will search into the directory, if a directory is specified.
+     *
+     * @param string $path    The path to search into
+     * @param string $default The default value to give back
+     *
+     * @return string|null
+     */
+    private function getDefaultConfigurationForPath(string $path = '.',
+                                                    string $default = null)
+    {
+        if ($this->isFile($path)) {
+            return realpath($path);
+        }
+
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $suffixes = [
+            'phpunit.xml',
+            'phpunit.xml.dist',
+        ];
+
+        foreach ($suffixes as $suffix) {
+            if ($this->isFile($path . $suffix)) {
+                return realpath($path . $suffix);
+            }
+        }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
the command to run phpunit passed the shell script to the php process and therefore crashed
fixed the default derivation of the phpunit run command to use the phpunit php script