### PR TITLE
Small tweaks

### DIFF
--- a/src/Console/Testers/PHPUnit.php
+++ b/src/Console/Testers/PHPUnit.php
@@ -220,7 +220,7 @@ class PHPUnit extends Tester
         $config = $this->getConfig($input);
         $bootstrap = $config->getBootstrap();
 
-        return ($bootstrap) ? $config->getConfigDir() . $bootstrap : '';
+        return $bootstrap ? $config->getConfigDir() . $bootstrap : '';
     }
 
     private function initializeRunner(InputInterface $input): BaseRunner

--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -177,12 +177,12 @@ class Reader extends MetaProvider
             $testCases[] = call_user_func_array($cb, [$c]);
             $result['name'] = (string) $c['class'];
             $result['file'] = (string) $c['file'];
-            $result['tests'] = $result['tests'] + 1;
+            $result['tests'] += 1;
             $result['assertions'] += (int) $c['assertions'];
             $result['failures'] += count($c->xpath('failure'));
             $result['errors'] += count($c->xpath('error'));
             $result['skipped'] += count($c->xpath('skipped'));
-            $result['time'] += (float) ($c['time']);
+            $result['time'] += (float) $c['time'];
 
             return $result;
         }, static::$defaultSuite);

--- a/src/Logging/LogInterpreter.php
+++ b/src/Logging/LogInterpreter.php
@@ -146,8 +146,8 @@ class LogInterpreter extends MetaProvider
     protected function getNumericValue(string $property)
     {
         return ($property === 'time')
-               ? (float) ($this->accumulate('getTotalTime'))
-               : (int) ($this->accumulate('getTotal' . ucfirst($property)));
+               ? (float) $this->accumulate('getTotalTime')
+               : (int) $this->accumulate('getTotal' . ucfirst($property));
     }
 
     /**

--- a/src/Logging/MetaProvider.php
+++ b/src/Logging/MetaProvider.php
@@ -54,8 +54,8 @@ abstract class MetaProvider
     protected function getNumericValue(string $property)
     {
         return ($property === 'time')
-            ? (float) ($this->suites[0]->$property)
-            : (int) ($this->suites[0]->$property);
+            ? (float) $this->suites[0]->$property
+            : (int) $this->suites[0]->$property;
     }
 
     /**

--- a/src/Parser/ParsedClass.php
+++ b/src/Parser/ParsedClass.php
@@ -49,7 +49,7 @@ class ParsedClass extends ParsedObject
             return false;
         });
 
-        return $methods ? $methods : $this->methods;
+        return $methods ?: $this->methods;
     }
 
     /**

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -61,7 +61,7 @@ class Parser
      */
     public function getClass()
     {
-        return ($this->refl->isAbstract())
+        return $this->refl->isAbstract()
             ? null
             : new ParsedClass(
                 (string) $this->refl->getDocComment(),

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -312,7 +312,7 @@ class Options
     {
         $annotatedOptions = ['group'];
         foreach ($this->filtered as $key => $value) {
-            if (array_search($key, $annotatedOptions, true) !== false) {
+            if (in_array($key, $annotatedOptions, true)) {
                 $this->annotations[$key] = $value;
             }
         }

--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -121,7 +121,7 @@ class ResultPrinter
     {
         $this->suites[] = $suite;
         $increment = $suite->getTestCount();
-        $this->totalCases = $this->totalCases + $increment;
+        $this->totalCases += $increment;
 
         return $this;
     }

--- a/src/Runners/PHPUnit/SqliteRunner.php
+++ b/src/Runners/PHPUnit/SqliteRunner.php
@@ -134,7 +134,7 @@ class SqliteRunner extends WrapperRunner
      */
     private function checkIfWorkersCrashed(): void
     {
-        if ($this->db->query('SELECT COUNT(id) FROM tests')->fetchColumn(0) === "0") {
+        if ($this->db->query('SELECT COUNT(id) FROM tests')->fetchColumn(0) === '0') {
             return;
         }
 

--- a/src/Runners/PHPUnit/TestFileLoader.php
+++ b/src/Runners/PHPUnit/TestFileLoader.php
@@ -93,7 +93,7 @@ class TestFileLoader
     {
         $this->files = [];
         $path = $path ?: $this->options->path;
-        $pattern = null === $pattern ? self::TEST_PATTERN : $pattern;
+        $pattern = $pattern ?? self::TEST_PATTERN;
 
         if (!file_exists($path)) {
             throw new \InvalidArgumentException("$path is not a valid directory or file");

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -20,7 +20,7 @@ define('PARATEST_ROOT', dirname(__DIR__));
 //check for .bat first if on windows.
 $phpunit_path = PARATEST_ROOT . DS . 'vendor' . DS . 'bin' . DS . 'phpunit';
 if (file_exists($phpunit_path . '.bat')) {
-    $phpunit_path = $phpunit_path . '.bat';
+    $phpunit_path .= '.bat';
 }
 define('PHPUNIT', $phpunit_path);
 

--- a/test/fixtures/dataprovider-tests/DataProviderTest.php
+++ b/test/fixtures/dataprovider-tests/DataProviderTest.php
@@ -32,7 +32,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
     {
         $result = [];
         for ($i = 0; $i < 50; $i++) {
-            $name = "name_of_test_" . $i;
+            $name = 'name_of_test_' . $i;
             $result[$name] = [$i, $i];
         }
 

--- a/test/fixtures/failing-tests/UnitTestWithErrorTest.php
+++ b/test/fixtures/failing-tests/UnitTestWithErrorTest.php
@@ -12,7 +12,7 @@ class UnitTestWithErrorTest extends UnitTestWithMethodAnnotationsTest
      */
     public function testTruth()
     {
-        throw new Exception("Error!!!");
+        throw new Exception('Error!!!');
         $this->assertTrue(true);
     }
 

--- a/test/fixtures/paratest-only-tests/TestTokenTest.php
+++ b/test/fixtures/paratest-only-tests/TestTokenTest.php
@@ -4,7 +4,7 @@ class TestTokenTest extends PHPUnit\FrameWork\TestCase
 {
     public function testThereIsAToken()
     {
-        $token = getenv("TEST_TOKEN");
+        $token = getenv('TEST_TOKEN');
         $this->assertTrue(false !== $token);
     }
 }

--- a/test/fixtures/passing-tests/GroupsTest.php
+++ b/test/fixtures/passing-tests/GroupsTest.php
@@ -33,7 +33,7 @@ class GroupsTest extends PHPUnit\FrameWork\TestCase
      */
     public function testStringLength()
     {
-        $string = "hello";
+        $string = 'hello';
         $this->assertEquals(5, strlen($string));
     }
 


### PR DESCRIPTION
Together with PHPStorm and https://github.com/kalessil/phpinspectionsea, here are some improvements that we can make to Paratest, such as unnecessaries parentheses; null coalesce operator usage; in_array instead of array_search + comparison, etc