### PR TITLE
[Feature] Allow setting processes to number of CPU cores

### DIFF
--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -116,6 +116,8 @@ class Options
 
         if ($opts['processes'] === 'auto') {
             $opts['processes'] = $this->getNumberOfCPUCores();
+        } elseif ($opts['processes'] === 'half') {
+            $opts['processes'] = intdiv($this->getNumberOfCPUCores(), 2);
         }
 
         $this->processes = $opts['processes'];

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -115,9 +115,9 @@ class Options
         }
 
         if ($opts['processes'] === 'auto') {
-            $opts['processes'] = $this->getNumberOfCPUCores();
+            $opts['processes'] = self::getNumberOfCPUCores();
         } elseif ($opts['processes'] === 'half') {
-            $opts['processes'] = intdiv($this->getNumberOfCPUCores(), 2);
+            $opts['processes'] = intdiv(self::getNumberOfCPUCores(), 2);
         }
 
         $this->processes = $opts['processes'];
@@ -334,8 +334,10 @@ class Options
      * Return number of (logical) CPU cores, use 2 as fallback.
      *
      * Used to set number of processes if argument is set to "auto", allows for portable defaults for doc and scripting.
+     *
+     * @internal
      */
-    private function getNumberOfCPUCores(): int
+    public static function getNumberOfCPUCores(): int
     {
         $cores = 2;
         if (is_file('/proc/cpuinfo')) {

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -114,6 +114,10 @@ class Options
             $opts[$opt] = $opts[$opt] ?? $value;
         }
 
+        if ($opts['processes'] === 'auto') {
+            $opts['processes'] = $this->getNumberOfCPUCores();
+        }
+
         $this->processes = $opts['processes'];
         $this->path = $opts['path'];
         $this->phpunit = $opts['phpunit'];
@@ -180,7 +184,7 @@ class Options
     protected static function defaults(): array
     {
         return [
-            'processes' => 5,
+            'processes' => 'auto',
             'path' => '',
             'phpunit' => static::phpunit(),
             'functional' => false,
@@ -322,5 +326,34 @@ class Options
     private function isFile(string $file): bool
     {
         return file_exists($file) && !is_dir($file);
+    }
+
+    /**
+     * Return number of (logical) CPU cores, use 2 as fallback.
+     *
+     * Used to set number of processes if argument is set to "auto", allows for portable defaults for doc and scripting.
+     */
+    private function getNumberOfCPUCores(): int
+    {
+        $cores = 2;
+        if (is_file('/proc/cpuinfo')) {
+            // Linux (and potentially Windows with linux sub systems)
+            $cpuinfo = file_get_contents('/proc/cpuinfo');
+            preg_match_all('/^processor/m', $cpuinfo, $matches);
+            $cores = count($matches[0]);
+        } elseif (DIRECTORY_SEPARATOR === '\\') {
+            // Windows
+            if (($process = @popen('wmic cpu get NumberOfCores', 'rb')) !== false) {
+                fgets($process);
+                $cores = (int) fgets($process);
+                pclose($process);
+            }
+        } elseif (($process = @popen('sysctl -n hw.ncpu', 'rb')) !== false) {
+            // *nix (Linux, BSD and Mac)
+            $cores = (int) fgets($process);
+            pclose($process);
+        }
+
+        return $cores;
     }
 }

--- a/test/unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/unit/Runners/PHPUnit/OptionsTest.php
@@ -29,6 +29,15 @@ class OptionsTest extends \TestBase
         $this->assertEquals('/path/to/bootstrap', $this->options->filtered['bootstrap']);
     }
 
+    public function testFilteredOptionsIsSet()
+    {
+        $this->assertEquals($this->unfiltered['processes'], $this->options->processes);
+        $this->assertEquals($this->unfiltered['path'], $this->options->path);
+        $this->assertEquals($this->unfiltered['phpunit'], $this->options->phpunit);
+        $this->assertEquals($this->unfiltered['functional'], $this->options->functional);
+        $this->assertEquals([$this->unfiltered['group']], $this->options->groups);
+    }
+
     public function testAnnotationsReturnsAnnotations()
     {
         $this->assertCount(1, $this->options->annotations);
@@ -44,10 +53,16 @@ class OptionsTest extends \TestBase
     public function testDefaults()
     {
         $options = new Options();
-        $this->assertEquals(5, $options->processes);
+        $this->assertEquals(Options::getNumberOfCPUCores(), $options->processes);
         $this->assertEmpty($options->path);
         $this->assertEquals(PHPUNIT, $options->phpunit);
         $this->assertFalse($options->functional);
+    }
+
+    public function testHalfProcessesMode()
+    {
+        $options = new Options(['processes' => 'half']);
+        $this->assertEquals(intdiv(Options::getNumberOfCPUCores(), 2), $options->processes);
     }
 
     public function testConfigurationShouldReturnXmlIfConfigNotSpecifiedAndFileExistsInCwd()

--- a/test/unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -59,7 +59,9 @@ class ResultPrinterTest extends ResultTester
     {
         $options = new Options();
         $contents = $this->getStartOutput($options);
-        $expected = sprintf("\nRunning phpunit in 5 processes with %s\n\n", $options->phpunit);
+        $expected = sprintf("\nRunning phpunit in %s processes with %s\n\n",
+                            Options::getNumberOfCPUCores(),
+                            $options->phpunit);
         $this->assertStringStartsWith($expected, $contents);
     }
 
@@ -83,7 +85,8 @@ class ResultPrinterTest extends ResultTester
         file_put_contents('myconfig.xml', '<root />');
         $options = new Options(['configuration' => 'myconfig.xml']);
         $contents = $this->getStartOutput($options);
-        $expected = sprintf("\nRunning phpunit in 5 processes with %s\n\nConfiguration read from %s\n\n",
+        $expected = sprintf("\nRunning phpunit in %s processes with %s\n\nConfiguration read from %s\n\n",
+                            Options::getNumberOfCPUCores(),
                             $options->phpunit,
                             __DIR__ . DS . 'myconfig.xml');
         $this->assertStringStartsWith($expected, $contents);
@@ -93,7 +96,9 @@ class ResultPrinterTest extends ResultTester
     {
         $options = new Options(['functional' => true]);
         $contents = $this->getStartOutput($options);
-        $expected = sprintf("\nRunning phpunit in 5 processes with %s. Functional mode is ON.\n\n", $options->phpunit);
+        $expected = sprintf("\nRunning phpunit in %s processes with %s. Functional mode is ON.\n\n",
+                            Options::getNumberOfCPUCores(),
+                            $options->phpunit);
         $this->assertStringStartsWith($expected, $contents);
     }
 


### PR DESCRIPTION
Makes it a bit more portable for documentation use, or scripting it (composer scripts, shell, ..).

I'm alos suggesting setting this as a default, however that is not a must here and up to what you see as best default for the project.