### PR TITLE
Change default console argument to auto

### DIFF
--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -39,7 +39,7 @@ class ParaTestCommand extends Command
     protected function configure()
     {
         $this
-            ->addOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 5)
+            ->addOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 'auto')
             ->addOption('functional', 'f', InputOption::VALUE_NONE, 'Run methods instead of suites in separate processes.')
             ->addOption('no-test-tokens', null, InputOption::VALUE_NONE, 'Disable TEST_TOKEN environment variables. <comment>(default: variable is set)</comment>')
             ->addOption('help', 'h', InputOption::VALUE_NONE, 'Display this help message.')


### PR DESCRIPTION
I forgot this part in prior pull request, so doc and command is not aligned now in 2.1.