### PR TITLE
Travis test - pin max phpunit version to ^7.5@dev instead of *@dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
 install:
   - if [[ $CS_CHECK == 'true' ]]; then phpenv config-rm xdebug.ini || return 0; else composer remove --dev --no-update --no-scripts friendsofphp/php-cs-fixer; fi;
-  - if [[ $PHPUNIT_DEV == 'true' ]]; then composer require --no-update phpunit/phpunit=*@dev; fi;
+  - if [[ $PHPUNIT_DEV == 'true' ]]; then composer require --no-update phpunit/phpunit=^7.5@dev; fi;
   - if [[ $DEPS == 'lowest' ]]; then COMPOSER_ARGS='--prefer-lowest --prefer-stable'; fi; composer update --no-interaction --prefer-dist $COMPOSER_ARGS
 
 script:


### PR DESCRIPTION
The phpunit TestCase setUp signature has changed in the latest master branch of phpunit in the commit https://github.com/sebastianbergmann/phpunit/commit/f5e5add13e73933c65878f53d5a94cdc0f120cc4#diff-511c90242d5589e941582006e0485184R407

Pin the highest tested version of phpunit to ^7.5@dev