### PR TITLE
Logfiles for WrapperRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ ParaTest
 The objective of ParaTest is to support parallel testing in PHPUnit. Provided you have well-written PHPUnit tests, you can drop `paratest` in your project and
 start using it with no additional bootstrap or configurations!
 
-Benefits
-------------
+# Benefits
 
 Why use `paratest` over the alternative parallel test runners out there?
 
@@ -18,23 +17,18 @@ Why use `paratest` over the alternative parallel test runners out there?
 * Zero configuration. *After composer install, run with `vendor/bin/paratest -p4 path/to/tests`. That's it!*
 * Flexible. *Isolate test files in separate processes or take advantage of WrapperRunner for even faster runs.*
 
-Installation
-------------
-
-### Composer ###
+# Installation
 
 To install with composer run the following command:
 
     composer require --dev brianium/paratest
     
-Versions
-------------
+# Versions
 For PHPUnit >= 7: Please use Paratest v2+
 
 For PHPUnit <= 6: Please use Paratest v1.
 
-Usage
------
+# Usage
 
 After installation, the binary can be found at `vendor/bin/paratest`. Usage is as follows:
 
@@ -79,7 +73,7 @@ Options:
  
 ```
 
-### Optimizing Speed ###
+### Optimizing Speed
 
 To get the most out of paratest, you have to adjust the parameters carefully.
 
@@ -114,7 +108,7 @@ To get the most out of paratest, you have to adjust the parameters carefully.
     Decrease max batch size to reduce command line length.
     Windows has limit around 32k, Linux - 2048k, Mac OS X - 256k.
 
-### Examples ###
+### Examples
 Examples assume your tests are located under `./test/unit`.
 
 ```
@@ -125,9 +119,16 @@ vendor/bin/paratest -p8 test/unit
 ```
 # Run all unit tests in 4 parallel processes with WrapperRunner and output html code coverage report to /tmp/coverage
 # (Code coverage requires Xdebug to be installed)
-vendor/bin/paratest -p8 --runner=WrapperRunner --coverage-html=/tmp/coverage test/unit
+vendor/bin/paratest -p4 --runner=WrapperRunner --coverage-html=/tmp/coverage test/unit
 ```
 
+### Troubleshooting
+If you run into problems with `paratest`, try to get more information about the issue by enabling debug output via `--verbose=1`.
+
+In case you are using the `WrapperRunner` for execution, consider enabling logging for troubleshooting via `export PT_LOGGING_ENABLE="true"`.
+The corresponding logfiles are placed in your `sys_get_temp_dir()`.
+
+See [Logging docs](docs/logging.md) for further information.
 
 ### Generating code coverage
 Examples assume your tests are located under `./test/unit`.
@@ -159,7 +160,7 @@ Code Coverage Report:
 **Caution**: Generating coverage is an art in itself. Please refer to our extensive guide on setting up everything correctly for 
 [code coverage generation with `paratest`](docs/code-coverage.md).
 
-### Windows ###
+### Windows
 
 Windows users be sure to use the appropriate batch files.
 
@@ -172,8 +173,7 @@ ParaTest assumes [PSR-0](https://github.com/php-fig/fig-standards/blob/master/ac
 For convenience paratest windows version use 79 columns mode to prevent blank lines in standard
 80x25 windows console.
 
-PHPUnit Xml Config Support
---------------------------
+# PHPUnit Xml Config Support
 
 When running PHPUnit tests, ParaTest will automatically pass the phpunit.xml or phpunit.xml.dist to the phpunit runner
 via the --configuration switch. ParaTest also allows the configuration path to be specified manually.
@@ -203,8 +203,7 @@ The following phpunit config file is used for ParaTest's test cases.
 </phpunit>
 ```
 
-Test token
-----------
+# Test token
 
 The `TEST_TOKEN` environment variable is guaranteed to have a value that is different
 from every other currently running test. This is useful to e.g. use a different database
@@ -218,8 +217,7 @@ if (getenv('TEST_TOKEN') !== false) {  // Using paratest
 }
 ```
 
-For Contributors: Testing paratest itself
--------------
+# For Contributors: Testing paratest itself
 
 ParaTest's test suite depends on PHPUnit being installed via composer. Make sure you run `composer install` after cloning.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ To get the most out of paratest, you have to adjust the parameters carefully.
     Windows has limit around 32k, Linux - 2048k, Mac OS X - 256k.
 
 ### Examples ###
-
 Examples assume your tests are located under `./test/unit`.
 
 ```
@@ -129,6 +128,36 @@ vendor/bin/paratest -p8 test/unit
 vendor/bin/paratest -p8 --runner=WrapperRunner --coverage-html=/tmp/coverage test/unit
 ```
 
+
+### Generating code coverage
+Examples assume your tests are located under `./test/unit`.
+````
+vendor/bin/paratest -p 1 --coverage-text test/unit
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+...............................................................  63 / 155 ( 40%)
+............................................................... 126 / 157 ( 80%)
+.....................................
+
+Time: 27.2 seconds, Memory: 8.00MB
+
+OK (163 tests, 328 assertions)
+
+
+Code Coverage Report:
+  2019-01-25 09:41:26
+
+ Summary:
+  Classes: 22.86% (8/35)
+  Methods: 49.47% (139/281)
+  Lines:   59.38% (896/1509)
+````
+
+**Caution**: Generating coverage is an art in itself. Please refer to our extensive guide on setting up everything correctly for 
+[code coverage generation with `paratest`](docs/code-coverage.md).
 
 ### Windows ###
 

--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -12,7 +12,22 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 
 $commands = fopen('php://stdin', 'r');
 $lastExitCode = 0;
+$rand = rand ( 0 , 999999 );
+$uniqueTestToken = getenv("UNIQUE_TEST_TOKEN") ?: "no_unique_test_token";
+$testToken = getenv("TEST_TOKEN") ?: "no_test_token";
+$filename = "paratest_t-{$testToken}_ut-{$uniqueTestToken}_r-{$rand}.log";
+$path = sys_get_temp_dir()."/".$filename;
+$loggingEnabled = getenv("PT_LOGGING_ENABLE");
+$logInfo = function(string $info) use ($path, $loggingEnabled){
+    if(!$loggingEnabled){
+        return;
+    }
+    file_put_contents($path, $info, FILE_APPEND | LOCK_EX);
+};
+
+$i = 0;
 while (true) {
+    $i++;
     if (feof($commands)) {
         exit($lastExitCode);
     }
@@ -27,11 +42,23 @@ while (true) {
     }
     echo "Executing: $command\n";
 
+    $info = [];
+    $info[] = "Time: ".(new \DateTime())->format(DateTime::RFC3339);
+    $info[] = "Iteration: $i";
+    $info[] = "Command: $command";
+    $info[] = PHP_EOL;
+    $infoText = implode(PHP_EOL,$info).PHP_EOL;
+    $logInfo($infoText);
+
     if (!preg_match_all('/\'([^\']*)\'[ ]?/', $command, $arguments)) {
         throw new \Exception("Failed to parse arguments from command line: \"" . $command . "\"");
     }
     $_SERVER['argv'] = $arguments[1];
 
+    ob_start();
     $lastExitCode = PHPUnit\TextUI\Command::main(false);
+    $infoText = ob_get_clean();
+    $logInfo($infoText);
+
     echo "FINISHED\n";
 }

--- a/docs/code-coverage.md
+++ b/docs/code-coverage.md
@@ -1,4 +1,4 @@
-# Code coverage
+# Code coverage generation with `paratest`
 `paratest` is able to generate code coverage in multiple output formats:
 ````
  --coverage-clover Generate code coverage report in Clover XML format.
@@ -8,19 +8,21 @@
  --coverage-xml    Generate code coverage report in PHPUnit XML format.
 ````
 
-It uses the corresponding options on the underlying `phpunit` library. `phpunit` itself relies on "external" help
-to get the coverage information (usually either `xdebug` or `phpdbg`). Further, it requires
+It uses the corresponding 
+[code coverage options on the underlying `phpunit` library](https://phpunit.readthedocs.io/en/7.4/code-coverage-analysis.html). 
+`phpunit` itself relies on "external" help
+to get the coverage information (usually either via `xdebug` or `phpdbg`). Further, it requires
 a correctly set-up `phpunit.xml` configuration file (including a `whitelist` filter).
 
 ## Preparing the `phpunit.xml` configuration file
-The configuration file *must* include a `<filter>` element that specifies a `<whitelist>`, see
+The configuration file **must** include a `<filter>` element that specifies a `<whitelist>`, see
 - [Whitelisting Files](https://phpunit.readthedocs.io/en/7.4/code-coverage-analysis.html#whitelisting-files)
 - [Whitelisting Files for Code Coverage](https://phpunit.readthedocs.io/en/7.4/configuration.html#whitelisting-files-for-code-coverage)
 
-*CAUTION: Making a mistake here is very often the reason for failing code coverage reports!*
+**CAUTION: Making a mistake here is very often the reason for failing code coverage reports!**
 
 Example:
-````
+````xml
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
@@ -58,16 +60,16 @@ Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
     with Xdebug v2.6.1, Copyright (c) 2002-2018, by Derick Rethans
 ````
 
-If the output is empty, you are either missing the extension completely or have not activated it. See the sections below 
-for troubleshooting and installation help.
+If the output is empty, you are either missing the extension completely or have not [activated](#xdebug-activation) it. See the sections below 
+for troubleshooting and [installation](#xdebug-installation) help.
 
 If `xdebug` is up and running, you can simply use `vendor/bin/paratest --coverage-text` to check if the code coverage generation is 
 working in general. Example for `paratest`s unit test suite:
 
 ````
-bin/paratest -p 1 --coverage-text test/unit
+bin/paratest -p 4 --coverage-text test/unit
 
-Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+Running phpunit in 4 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
 
 Configuration read from /codebase/paratest/phpunit.xml.dist
 
@@ -75,7 +77,7 @@ Configuration read from /codebase/paratest/phpunit.xml.dist
 ............................................................... 126 / 157 ( 80%)
 .....................................
 
-Time: 27.2 seconds, Memory: 8.00MB
+Time: 12.2 seconds, Memory: 8.00MB
 
 OK (163 tests, 328 assertions)
 
@@ -143,7 +145,7 @@ Code Coverage Report:
 
 ````
 
-If you want to enable [xdebug on premise](#on-premise-activation), it gets a little bit more complicated due to subprocess structure that `paratest` uses.
+If you want to enable [xdebug on premise](#on-premise-activation), it gets a little bit more complicated due to the subprocess structure that `paratest` uses.
 We need to not only invoke `paratest` itself with `xdebug` enabled but need to also tell it to invoke the subprocesses in that way.
 This can can be done with the [`--passthru-php` option](https://github.com/paratestphp/paratest/issues/360).
 
@@ -160,9 +162,9 @@ This will
 
 Example for `paratest`s unit test suite:
 ````
-php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' bin/paratest -p 1 --coverage-text test/unit --passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' "
+php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' bin/paratest -p 4 --coverage-text test/unit --passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' "
 
-Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+Running phpunit in 4 processes with /codebase/paratest/vendor/phpunit/phpunit/phpunit
 
 Configuration read from /codebase/paratest/phpunit.xml.dist
 
@@ -170,7 +172,7 @@ Configuration read from /codebase/paratest/phpunit.xml.dist
 ............................................................... 126 / 157 ( 80%)
 .....................................
 
-Time: 22.93 seconds, Memory: 8.00MB
+Time: 8.93 seconds, Memory: 8.00MB
 
 OK (163 tests, 328 assertions)
 
@@ -265,9 +267,12 @@ Note that we restrict xdebugs code coverage now to the `src/Util` directory.
 Then, I run `bin/paratest -p 1 --coverage-text --passthru="'--prepend' 'xdebug-filter.php'" test/unit` to run only the unit tests. 
 Result:
 ````
-bin/paratest -p 1 --coverage-text --passthru="'--prepend' 'xdebug-filter.php'" test/unit
+php -m | grep xdebug
+xdebug
 
-Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+bin/paratest -p 4 --coverage-text --passthru="'--prepend' 'xdebug-filter.php'" test/unit
+
+Running phpunit in 4 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
 
 Configuration read from /codebase/paratest/phpunit.xml.dist
 
@@ -275,7 +280,7 @@ Configuration read from /codebase/paratest/phpunit.xml.dist
 ............................................................... 126 / 157 ( 80%)
 .....................................
 
-Time: 11.45 seconds, Memory: 4.00MB
+Time: 6.45 seconds, Memory: 4.00MB
 
 OK (163 tests, 328 assertions)
 
@@ -293,6 +298,11 @@ Code Coverage Report:
 ````
 Note that this is *much* faster as before, *but* also only contains coverage for `src/Util`. Usually, we would set the filter to `src`,
 but for the sake of demonstrating the functionality I'm using `src/Util`.
+
+The above example assumes that xdebug is activated. You can also combine this approach with on-premise activation:
+````
+`php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' vendor/bin/paratest --coverage-text --passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so'" --passthru="'--prepend' 'xdebug-filter.php'"`
+````
 
 ### xdebug installation
 - [Official installation guide](https://xdebug.org/docs/install)
@@ -323,7 +333,7 @@ but for the sake of demonstrating the functionality I'm using `src/Util`.
   ````
   sudo phpenmod xdebug
   ````
-- For Docker:
+- [For Docker](https://www.pascallandau.com/blog/php-php-fpm-and-nginx-on-docker-in-windows-10/#xdebug-php):
   ````
   docker-php-ext-enable xdebug
   ````
@@ -356,15 +366,15 @@ First, check if `phpdbg` is available on your system:
 which phpdbg
 /usr/bin/phpdbg
 ````
-If the result is empty, `phpdbg` is probably missing from your system.
+If the result is empty, `phpdbg` is probably missing from your system. See [phpdbg installation](#phpdbg-installation) for further instructions.
 
 If `phpdbg` is available, you need to invoke paratest e.g. via  `phpdbg -qrr vendor/bin/paratest --coverage-text`.
 Example for `paratest`s unit test suite:
 
 ````
-phpdbg -qrr bin/paratest -p 1 --coverage-text test/unit
+phpdbg -qrr bin/paratest -p 4 --coverage-text test/unit
 
-Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+Running phpunit in 4 processes with /codebase/paratest/vendor/phpunit/phpunit/phpunit
 
 Configuration read from /codebase/paratest/phpunit.xml.dist
 
@@ -372,7 +382,7 @@ Configuration read from /codebase/paratest/phpunit.xml.dist
 ............................................................... 126 / 157 ( 80%)
 .....................................
 
-Time: 12.67 seconds, Memory: 16.00MB
+Time: 6.67 seconds, Memory: 16.00MB
 
 OK (163 tests, 328 assertions)
 
@@ -466,11 +476,11 @@ Time: 604 ms, Memory: 4.00MB
 OK (5 tests, 5 assertions)
 ````
 
-### Coverage file /tmp/CV_B8u8f3 is empty. Xdebug is disabled! Enable for coverage.
-`paratest` can't find xdebug. Please see [xdebug installation](#xdebug-installation) and [xdebug activation](xdebug-activation)
+### Error: Coverage file /tmp/CV_B8u8f3 is empty. Xdebug is disabled! Enable for coverage.
+`paratest` can't find xdebug. Please see [xdebug installation](#xdebug-installation) and [xdebug activation](#xdebug-activation)
 
-### Coverage file /tmp/CV_ZV3Wdd is empty. This means a PHPUnit process has crashed.
+### Error: Coverage file /tmp/CV_ZV3Wdd is empty. This means a PHPUnit process has crashed.
 Unfortunately, this error is very generic. It just means that _something_ has gone wrong but we basically don't know what.
 Things to check:
 - is your `/tmp` folder writable?
-- check [## Preparing the `phpunit.xml` configuration file](#preparing-the-phpunit-xml-configuration-file)
+- check if your phpunit configuration file is correct (see [Preparing the `phpunit.xml` configuration file](#preparing-the-phpunit-xml-configuration-file))

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,97 @@
+# Logging WrapperRunner output
+The `--runner WrapperRunner` option will start the script in `bin/phpunit-wrapper` as a long running process
+and send individual tests in via stdin/pipes. In order to make the execution of the process easier to understand,
+you can set the environment variable `PT_LOGGING_ENABLE` to true.
+
+## Enable logging: set `PT_LOGGING_ENABLE`
+Set the `PT_LOGGING_ENABLE` variable only for the `paratest` process:
+````
+PT_LOGGING_ENABLE="true" vendor/bin/paratest
+````
+
+Set the `PT_LOGGING_ENABLE` variable globally:
+````
+export PT_LOGGING_ENABLE="true" 
+vendor/bin/paratest
+````
+
+## Logfiles
+The logfiles are placed in the directory returned by `sys_get_temp_dir()`. The filename is determined 
+from the given `TEST_TOKEN`, `UNIQUE_TEST_TOKEN` and a random number via
+````
+$uniqueTestToken = getenv("UNIQUE_TEST_TOKEN") ?: "no_unique_test_token";
+$testToken = getenv("TEST_TOKEN") ?: "no_test_token";
+$filename = "paratest_t-{$testToken}_ut-{$uniqueTestToken}_r-{$rand}.log";
+$path = sys_get_temp_dir()."/".$filename;
+````
+If in doubt just check the contents of `bin/phpunit-wrapper`. 
+
+The resulting file names look like this:
+````
+ls -l /tmp
+total 5
+-rw-r--r-- 1 root root  Jan 25 17:57 paratest_t-1_ut-5c4b4e136692d_r-457700.log
+-rw-r--r-- 1 root root  Jan 25 17:57 paratest_t-2_ut-5c4b4e136855c_r-916202.log
+-rw-r--r-- 1 root root  Jan 25 17:57 paratest_t-3_ut-5c4b4e1368ada_r-75267.log
+-rw-r--r-- 1 root root  Jan 25 17:57 paratest_t-4_ut-5c4b4e1368ecf_r-536174.log
+-rw-r--r-- 1 root root  Jan 25 17:57 paratest_t-5_ut-5c4b4e136932c_r-666883.log
+````
+
+If paratest is run with the `--no-test-tokens` option, the files look like this:
+````
+ls -l /tmp
+total 5
+-rw-r--r-- 1 root root  Jan 25 17:59 paratest_t-no_test_token_ut-no_unique_test_token_r-142884.log
+-rw-r--r-- 1 root root  Jan 25 17:59 paratest_t-no_test_token_ut-no_unique_test_token_r-351471.log
+-rw-r--r-- 1 root root  Jan 25 17:59 paratest_t-no_test_token_ut-no_unique_test_token_r-455307.log
+-rw-r--r-- 1 root root  Jan 25 17:59 paratest_t-no_test_token_ut-no_unique_test_token_r-824877.log
+-rw-r--r-- 1 root root  Jan 25 17:59 paratest_t-no_test_token_ut-no_unique_test_token_r-827359.log
+````
+
+## Logged info
+The logged information contains:
+- Iteration: the incrementing job number
+- Time: current timestamp in RFC3339 format
+- Command: The command that is being executed
+- verbatim output of the command captured by `ob_start()` and returned by `ob_get_clean()`
+
+Example:
+````
+cat /tmp/paratest_t-5_ut-5c4b4e136932c_r-666883.log
+Time: 2019-01-25T18:19:09+00:00
+Iteration: 1
+Command: '/codebase/paratest/vendor/phpunit/phpunit/phpunit' '--configuration' '/codebase/paratest/phpunit.xml.dist' '--log-junit' '/tmp/PT_e4yf1N' 'ParaTest\Console\VersionProviderTest' 'test/unit//Console/VersionProviderTest.php'
+
+
+PHPUnit 7.5.2 by Sebastian Bergmann and contributors.
+
+....                                                                4 / 4 (100%)
+
+Time: 806 ms, Memory: 4.00MB
+
+OK (4 tests, 7 assertions)
+Time: 2019-01-25T18:19:10+00:00
+Iteration: 2
+Command: '/codebase/paratest/vendor/phpunit/phpunit/phpunit' '--configuration' '/codebase/paratest/phpunit.xml.dist' '--log-junit' '/tmp/PT_wGmQPE' 'ParaTest\Runners\PHPUnit\SuiteTest' 'test/unit//Runners/PHPUnit/SuiteTest.php'
+
+
+PHPUnit 7.5.2 by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: 826 ms, Memory: 4.00MB
+
+OK (1 test, 1 assertion)
+Time: 2019-01-25T18:19:10+00:00
+Iteration: 3
+Command: '/codebase/paratest/vendor/phpunit/phpunit/phpunit' '--configuration' '/codebase/paratest/phpunit.xml.dist' '--log-junit' '/tmp/PT_E2vYmt' 'ParaTest\Runners\PHPUnit\TestMethodTest' 'test/unit//Runners/PHPUnit/TestMethodTest.php'
+
+
+PHPUnit 7.5.2 by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: 845 ms, Memory: 4.00MB
+
+OK (1 test, 1 assertion)
+````

--- a/docu/code-coverage.md
+++ b/docu/code-coverage.md
@@ -1,0 +1,476 @@
+# Code coverage
+`paratest` is able to generate code coverage in multiple output formats:
+````
+ --coverage-clover Generate code coverage report in Clover XML format.
+ --coverage-html   Generate code coverage report in HTML format.
+ --coverage-php    Serialize PHP_CodeCoverage object to file.
+ --coverage-text   Generate code coverage report in text format.
+ --coverage-xml    Generate code coverage report in PHPUnit XML format.
+````
+
+It uses the corresponding options on the underlying `phpunit` library. `phpunit` itself relies on "external" help
+to get the coverage information (usually either `xdebug` or `phpdbg`). Further, it requires
+a correctly set-up `phpunit.xml` configuration file (including a `whitelist` filter).
+
+## Preparing the `phpunit.xml` configuration file
+The configuration file *must* include a `<filter>` element that specifies a `<whitelist>`, see
+- [Whitelisting Files](https://phpunit.readthedocs.io/en/7.4/code-coverage-analysis.html#whitelisting-files)
+- [Whitelisting Files for Code Coverage](https://phpunit.readthedocs.io/en/7.4/configuration.html#whitelisting-files-for-code-coverage)
+
+*CAUTION: Making a mistake here is very often the reason for failing code coverage reports!*
+
+Example:
+````
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>
+````
+
+## Code coverage with xdebug
+First, check if `xdebug` is enabled:
+````
+php -m | grep xdebug
+xdebug
+````
+or
+````
+php -v
+PHP 7.2.14-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jan 13 2019 10:05:18) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    with Xdebug v2.6.1, Copyright (c) 2002-2018, by Derick Rethans
+````
+
+If the output is empty, you are either missing the extension completely or have not activated it. See the sections below 
+for troubleshooting and installation help.
+
+If `xdebug` is up and running, you can simply use `vendor/bin/paratest --coverage-text` to check if the code coverage generation is 
+working in general. Example for `paratest`s unit test suite:
+
+````
+bin/paratest -p 1 --coverage-text test/unit
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+...............................................................  63 / 155 ( 40%)
+............................................................... 126 / 157 ( 80%)
+.....................................
+
+Time: 27.2 seconds, Memory: 8.00MB
+
+OK (163 tests, 328 assertions)
+
+
+Code Coverage Report:
+  2019-01-25 09:41:26
+
+ Summary:
+  Classes: 22.86% (8/35)
+  Methods: 49.47% (139/281)
+  Lines:   59.38% (896/1509)
+
+\ParaTest\Console::ParaTest\Console\VersionProvider
+  Methods:  50.00% ( 3/ 6)   Lines:  81.08% ( 30/ 37)
+\ParaTest\Console\Commands::ParaTest\Console\Commands\ParaTestCommand
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 24/ 24)
+\ParaTest\Console\Testers::ParaTest\Console\Testers\PHPUnit
+  Methods:  18.18% ( 2/11)   Lines:  29.73% ( 22/ 74)
+\ParaTest\Coverage::ParaTest\Coverage\CoverageMerger
+  Methods:  25.00% ( 1/ 4)   Lines:  19.05% (  4/ 21)
+\ParaTest\Logging::ParaTest\Logging\LogInterpreter
+  Methods:  81.82% ( 9/11)   Lines:  93.75% ( 45/ 48)
+\ParaTest\Logging::ParaTest\Logging\MetaProvider
+  Methods:  66.67% ( 2/ 3)   Lines:  93.75% ( 15/ 16)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Reader
+  Methods:  81.82% ( 9/11)   Lines:  97.01% ( 65/ 67)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestCase
+  Methods:  71.43% ( 5/ 7)   Lines:  92.68% ( 38/ 41)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestSuite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 27/ 27)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Writer
+  Methods: 100.00% (10/10)   Lines: 100.00% ( 57/ 57)
+\ParaTest\Parser::ParaTest\Parser\ParsedClass
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 12/ 12)
+\ParaTest\Parser::ParaTest\Parser\ParsedFunction
+  Methods:  50.00% ( 1/ 2)   Lines:  75.00% (  3/  4)
+\ParaTest\Parser::ParaTest\Parser\ParsedObject
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 10/ 10)
+\ParaTest\Parser::ParaTest\Parser\Parser
+  Methods:  87.50% ( 7/ 8)   Lines:  96.15% ( 50/ 52)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\BaseRunner
+  Methods:  16.67% ( 2/12)   Lines:   8.93% (  5/ 56)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Configuration
+  Methods:  83.33% (10/12)   Lines:  94.03% ( 63/ 67)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ExecutableTest
+  Methods:  52.17% (12/23)   Lines:  63.16% ( 48/ 76)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Options
+  Methods:  66.67% ( 8/12)   Lines:  92.63% ( 88/ 95)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ResultPrinter
+  Methods:  53.57% (15/28)   Lines:  74.66% (109/146)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Runner
+  Methods:  36.36% ( 4/11)   Lines:  23.19% ( 16/ 69)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Suite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  5/  5)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuiteLoader
+  Methods:  44.44% ( 8/18)   Lines:  78.91% (101/128)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuitePath
+  Methods: 100.00% ( 5/ 5)   Lines: 100.00% ( 10/ 10)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestFileLoader
+  Methods:  83.33% ( 5/ 6)   Lines:  94.74% ( 36/ 38)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestMethod
+  Methods:  60.00% ( 3/ 5)   Lines:  45.45% (  5/ 11)
+\ParaTest\Util::ParaTest\Util\Str
+  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  8/  8)
+
+````
+
+If you want to enable [xdebug on premise](#on-premise-activation), it gets a little bit more complicated due to subprocess structure that `paratest` uses.
+We need to not only invoke `paratest` itself with `xdebug` enabled but need to also tell it to invoke the subprocesses in that way.
+This can can be done with the [`--passthru-php` option](https://github.com/paratestphp/paratest/issues/360).
+
+Assuming that 
+- xdebug is installed but deactivated
+- the extension is located at `/usr/lib/php/20170718/xdebug.so`
+
+you can invoke code coverage generation via 
+`php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' vendor/bin/paratest --coverage-text --passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so'"`
+
+This will 
+- invoke paratest with xdebug enabled (`php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' vendor/bin/paratest`)
+- invoke the subprocesses with xdebug enabled (`--passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so'"`)
+
+Example for `paratest`s unit test suite:
+````
+php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' bin/paratest -p 1 --coverage-text test/unit --passthru-php="'-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' "
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+...............................................................  63 / 155 ( 40%)
+............................................................... 126 / 157 ( 80%)
+.....................................
+
+Time: 22.93 seconds, Memory: 8.00MB
+
+OK (163 tests, 328 assertions)
+
+
+Code Coverage Report:
+  2019-01-25 10:41:04
+
+ Summary:
+  Classes: 22.86% (8/35)
+  Methods: 49.47% (139/281)
+  Lines:   59.38% (896/1509)
+
+\ParaTest\Console::ParaTest\Console\VersionProvider
+  Methods:  50.00% ( 3/ 6)   Lines:  81.08% ( 30/ 37)
+\ParaTest\Console\Commands::ParaTest\Console\Commands\ParaTestCommand
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 24/ 24)
+\ParaTest\Console\Testers::ParaTest\Console\Testers\PHPUnit
+  Methods:  18.18% ( 2/11)   Lines:  29.73% ( 22/ 74)
+\ParaTest\Coverage::ParaTest\Coverage\CoverageMerger
+  Methods:  25.00% ( 1/ 4)   Lines:  19.05% (  4/ 21)
+\ParaTest\Logging::ParaTest\Logging\LogInterpreter
+  Methods:  81.82% ( 9/11)   Lines:  93.75% ( 45/ 48)
+\ParaTest\Logging::ParaTest\Logging\MetaProvider
+  Methods:  66.67% ( 2/ 3)   Lines:  93.75% ( 15/ 16)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Reader
+  Methods:  81.82% ( 9/11)   Lines:  97.01% ( 65/ 67)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestCase
+  Methods:  71.43% ( 5/ 7)   Lines:  92.68% ( 38/ 41)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestSuite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 27/ 27)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Writer
+  Methods: 100.00% (10/10)   Lines: 100.00% ( 57/ 57)
+\ParaTest\Parser::ParaTest\Parser\ParsedClass
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 12/ 12)
+\ParaTest\Parser::ParaTest\Parser\ParsedFunction
+  Methods:  50.00% ( 1/ 2)   Lines:  75.00% (  3/  4)
+\ParaTest\Parser::ParaTest\Parser\ParsedObject
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 10/ 10)
+\ParaTest\Parser::ParaTest\Parser\Parser
+  Methods:  87.50% ( 7/ 8)   Lines:  96.15% ( 50/ 52)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\BaseRunner
+  Methods:  16.67% ( 2/12)   Lines:   8.93% (  5/ 56)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Configuration
+  Methods:  83.33% (10/12)   Lines:  94.03% ( 63/ 67)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ExecutableTest
+  Methods:  52.17% (12/23)   Lines:  63.16% ( 48/ 76)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Options
+  Methods:  66.67% ( 8/12)   Lines:  92.63% ( 88/ 95)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ResultPrinter
+  Methods:  53.57% (15/28)   Lines:  74.66% (109/146)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Runner
+  Methods:  36.36% ( 4/11)   Lines:  23.19% ( 16/ 69)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Suite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  5/  5)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuiteLoader
+  Methods:  44.44% ( 8/18)   Lines:  78.91% (101/128)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuitePath
+  Methods: 100.00% ( 5/ 5)   Lines: 100.00% ( 10/ 10)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestFileLoader
+  Methods:  83.33% ( 5/ 6)   Lines:  94.74% ( 36/ 38)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestMethod
+  Methods:  60.00% ( 3/ 5)   Lines:  45.45% (  5/ 11)
+\ParaTest\Util::ParaTest\Util\Str
+  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  8/  8)
+````
+
+### Using phpunits `--prepend` option for faster code coverage
+`xdebug` supports filtering for which files it generates code coverage via `xdebug_set_filter`. 
+In January 2019, Sebastian Bergmann published [Faster Code Coverage](https://thephp.cc/news/2019/01/faster-code-coverage) and explains
+on how this functionality can be integrated with `phpunit`. Please refer to the article for further information.
+
+To get this to work in `paratest`, we'll need to use the `--passthru` option for now. That option enables passing verbatim arguments
+to the underlying phpunit command. Example for `paratest`:
+
+First, im creating `xdebug-filter.php` in the root of the repository with
+````
+<?php declare(strict_types=1);
+if (!\function_exists('xdebug_set_filter')) {
+    throw new Exception("xdebug_set_filter not available on system");
+}
+
+\xdebug_set_filter(
+    \XDEBUG_FILTER_CODE_COVERAGE,
+    \XDEBUG_PATH_WHITELIST,
+    [
+        __DIR__.'/src/Util',
+    ]
+);
+````
+Note that we restrict xdebugs code coverage now to the `src/Util` directory.
+
+Then, I run `bin/paratest -p 1 --coverage-text --passthru="'--prepend' 'xdebug-filter.php'" test/unit` to run only the unit tests. 
+Result:
+````
+bin/paratest -p 1 --coverage-text --passthru="'--prepend' 'xdebug-filter.php'" test/unit
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+...............................................................  63 / 155 ( 40%)
+............................................................... 126 / 157 ( 80%)
+.....................................
+
+Time: 11.45 seconds, Memory: 4.00MB
+
+OK (163 tests, 328 assertions)
+
+
+Code Coverage Report:
+  2019-01-25 11:07:16
+
+ Summary:
+  Classes:  2.86% (1/35)
+  Methods:  0.36% (1/281)
+  Lines:    0.35% (8/2311)
+
+\ParaTest\Util::ParaTest\Util\Str
+  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  8/  8)
+````
+Note that this is *much* faster as before, *but* also only contains coverage for `src/Util`. Usually, we would set the filter to `src`,
+but for the sake of demonstrating the functionality I'm using `src/Util`.
+
+### xdebug installation
+- [Official installation guide](https://xdebug.org/docs/install)
+- [Install via apt-get](http://www.dieuwe.com/blog/xdebug-ubuntu-1604-php7)
+  - Note: For the latest PHP versions you might need to update your apt repositories first, usually via `add-apt-repository ppa:ondrej/php && apt-get update`.
+    See also https://tecadmin.net/install-php-7-on-ubuntu/
+- [Install in docker](https://www.pascallandau.com/blog/php-php-fpm-and-nginx-on-docker-in-windows-10/#xdebug-php)
+- [Install on windows](https://www.pascallandau.com/blog/php7-with-xdebug-2-4-for-phpstorm-on-windows-10/#installing-xdebug)
+
+### xdebug activation
+- Generally: Make sure the `xdebug` extension is loaded, i.e. your `php.ini` must contain the line
+  ````
+  zend_extension=xdebug.so
+  ````
+  where `xdebug.so` can also be the path to the actual `.so` file (e.g. `/usr/lib/php/20180731/xdebug.so`).
+  Hint: Usually this is not put directly in the `php.ini` but in `conf.d/xdebug.ini` where `conf.d/` is the the 
+  directory that `php.ini` uses to load additional `.ini` files.
+  If you don't know where the extension is located on your system, `sudo find / -name xdebug.so` might help:
+  ````
+  sudo find / -name xdebug.so
+  /usr/lib/php/20160303/xdebug.so
+  /usr/lib/php/20180731/xdebug.so
+  /usr/lib/php/20170718/xdebug.so
+  /usr/lib/php/20151012/xdebug.so
+  /usr/lib/php/20131226/xdebug.so
+  ````
+- If you are running ubuntu, you can probably just use `phpenmod` to activate the extension:
+  ````
+  sudo phpenmod xdebug
+  ````
+- For Docker:
+  ````
+  docker-php-ext-enable xdebug
+  ````
+  
+### On-premise activation
+You can also enable `xdebug` on premise via [`-d` flag](http://php.net/manual/en/features.commandline.options.php) with
+`php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so'`:
+````
+php -v
+PHP 7.2.14-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jan 13 2019 10:05:18) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    
+php '-d' 'zend_extension=/usr/lib/php/20170718/xdebug.so' -v
+PHP 7.2.14-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Jan 13 2019 10:05:18) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    with Xdebug v2.6.1, Copyright (c) 2002-2018, by Derick Rethans
+````
+
+Oftentimes this is a desired feature because having `xdebug` enabled comes with a performance penalty.
+
+## Code coverage with phpdbg
+`phpdbg` [has built up a reputation](https://hackernoon.com/generating-code-coverage-with-phpunite-and-phpdbg-4d20347ffb45) 
+as a much faster tool to generate code coverage compared to xdebug.
+You can find the official introduction at http://php.net/phpdbg
+
+First, check if `phpdbg` is available on your system:
+```` 
+which phpdbg
+/usr/bin/phpdbg
+````
+If the result is empty, `phpdbg` is probably missing from your system.
+
+If `phpdbg` is available, you need to invoke paratest e.g. via  `phpdbg -qrr vendor/bin/paratest --coverage-text`.
+Example for `paratest`s unit test suite:
+
+````
+phpdbg -qrr bin/paratest -p 1 --coverage-text test/unit
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+...............................................................  63 / 155 ( 40%)
+............................................................... 126 / 157 ( 80%)
+.....................................
+
+Time: 12.67 seconds, Memory: 16.00MB
+
+OK (163 tests, 328 assertions)
+
+
+Code Coverage Report:
+  2019-01-25 10:56:12
+
+ Summary:
+  Classes: 25.71% (9/35)
+  Methods: 50.71% (142/280)
+  Lines:   60.31% (825/1368)
+
+\ParaTest\Console::ParaTest\Console\VersionProvider
+  Methods:  66.67% ( 4/ 6)   Lines:  86.21% ( 25/ 29)
+\ParaTest\Console\Commands::ParaTest\Console\Commands\ParaTestCommand
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% ( 22/ 22)
+\ParaTest\Console\Testers::ParaTest\Console\Testers\PHPUnit
+  Methods:  18.18% ( 2/11)   Lines:  26.76% ( 19/ 71)
+\ParaTest\Coverage::ParaTest\Coverage\CoverageMerger
+  Methods:  25.00% ( 1/ 4)   Lines:  20.00% (  4/ 20)
+\ParaTest\Logging::ParaTest\Logging\LogInterpreter
+  Methods:  81.82% ( 9/11)   Lines:  95.65% ( 44/ 46)
+\ParaTest\Logging::ParaTest\Logging\MetaProvider
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 15/ 15)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Reader
+  Methods:  81.82% ( 9/11)   Lines:  96.83% ( 61/ 63)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestCase
+  Methods:  71.43% ( 5/ 7)   Lines:  94.29% ( 33/ 35)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\TestSuite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 26/ 26)
+\ParaTest\Logging\JUnit::ParaTest\Logging\JUnit\Writer
+  Methods: 100.00% (10/10)   Lines: 100.00% ( 53/ 53)
+\ParaTest\Parser::ParaTest\Parser\ParsedClass
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% ( 11/ 11)
+\ParaTest\Parser::ParaTest\Parser\ParsedFunction
+  Methods:  50.00% ( 1/ 2)   Lines:  66.67% (  2/  3)
+\ParaTest\Parser::ParaTest\Parser\ParsedObject
+  Methods: 100.00% ( 4/ 4)   Lines: 100.00% (  9/  9)
+\ParaTest\Parser::ParaTest\Parser\Parser
+  Methods:  87.50% ( 7/ 8)   Lines:  96.08% ( 49/ 51)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\BaseRunner
+  Methods:  16.67% ( 2/12)   Lines:   8.51% (  4/ 47)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Configuration
+  Methods:  75.00% ( 9/12)   Lines:  90.62% ( 58/ 64)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ExecutableTest
+  Methods:  54.55% (12/22)   Lines:  65.22% ( 45/ 69)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Options
+  Methods:  75.00% ( 9/12)   Lines:  93.33% ( 84/ 90)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\ResultPrinter
+  Methods:  53.57% (15/28)   Lines:  75.00% ( 99/132)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Runner
+  Methods:  36.36% ( 4/11)   Lines:  21.67% ( 13/ 60)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\Suite
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  4/  4)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuiteLoader
+  Methods:  50.00% ( 9/18)   Lines:  78.15% ( 93/119)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\SuitePath
+  Methods: 100.00% ( 5/ 5)   Lines: 100.00% (  9/  9)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestFileLoader
+  Methods:  83.33% ( 5/ 6)   Lines:  94.12% ( 32/ 34)
+\ParaTest\Runners\PHPUnit::ParaTest\Runners\PHPUnit\TestMethod
+  Methods:  60.00% ( 3/ 5)   Lines:  40.00% (  4/ 10)
+\ParaTest\Util::ParaTest\Util\Str
+  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  7/  7)
+````
+
+### `phpdbg` installation
+`phpdbg` ships with `php-src` and can be compiled as per https://github.com/krakjoe/phpdbg#installation
+
+However, you can usually install it simply via `apt-get` with `apt-get update && apt-get install php-phpdbg`.
+(Note: I've never done this for Windows).
+
+## Troubleshooting
+If anything goes wrong, you should enable debug output via `--verbose=1`. This should give you an idea what comamnds `paratest`
+is actually running. Example:
+
+````
+bin/paratest -p 1 test/unit/Util/StrTest.php --verbose=1 --runner WrapperRunner
+
+Running phpunit in 1 process with /codebase/paratest/vendor/phpunit/phpunit/phpunit
+
+Configuration read from /codebase/paratest/phpunit.xml.dist
+
+Starting WrapperWorker via: PARATEST=1 XDEBUG_CONFIG="true" TEST_TOKEN=1 UNIQUE_TEST_TOKEN=5c4af2d88c0d9 /usr/bin/php7.2  "/codebase/paratest/bin/phpunit-wrapper"
+
+Executing test via: '/codebase/paratest/vendor/phpunit/phpunit/phpunit' '--configuration' '/codebase/paratest/phpunit.xml.dist' '--log-junit' '/tmp/PT_tIUjT5' 'ParaTest\Util\StrTest' 'test/unit/Util/StrTest.php'
+.....
+
+Time: 604 ms, Memory: 4.00MB
+
+OK (5 tests, 5 assertions)
+````
+
+### Coverage file /tmp/CV_B8u8f3 is empty. Xdebug is disabled! Enable for coverage.
+`paratest` can't find xdebug. Please see [xdebug installation](#xdebug-installation) and [xdebug activation](xdebug-activation)
+
+### Coverage file /tmp/CV_ZV3Wdd is empty. This means a PHPUnit process has crashed.
+Unfortunately, this error is very generic. It just means that _something_ has gone wrong but we basically don't know what.
+Things to check:
+- is your `/tmp` folder writable?
+- check [## Preparing the `phpunit.xml` configuration file](#preparing-the-phpunit-xml-configuration-file)

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -39,7 +39,7 @@ abstract class BaseRunner
      * A collection of ExecutableTest objects that have processes
      * currently running.
      *
-     * @var array
+     * @var array|ExecutableTest[]
      */
     protected $running = [];
 

--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -31,9 +31,19 @@ class Runner extends BaseRunner
 
         while (\count($this->running) || \count($this->pending)) {
             foreach ($this->running as $key => $test) {
-                if (!$this->testIsStillRunning($test)) {
-                    unset($this->running[$key]);
-                    $this->releaseToken($key);
+                try {
+                    if (!$this->testIsStillRunning($test)) {
+                        unset($this->running[$key]);
+                        $this->releaseToken($key);
+                    }
+                } catch (\Exception $e) {
+                    if ($this->options->verbose) {
+                        echo "An error for $key: {$e->getMessage()}" . PHP_EOL;
+                        echo "Command: {$test->getLastCommand()}" . PHP_EOL;
+                        echo 'StdErr: ' . $test->getStderr() . PHP_EOL;
+                        echo 'StdOut: ' . $test->getStdout() . PHP_EOL;
+                    }
+                    throw $e;
                 }
             }
             $this->fillRunQueue();

--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -74,6 +74,10 @@ class Runner extends BaseRunner
                 $this->acquireToken($tokenData['token']);
                 $env = ['TEST_TOKEN' => $tokenData['token'], 'UNIQUE_TEST_TOKEN' => $tokenData['unique']] + Habitat::getAll();
                 $this->running[$tokenData['token']] = array_shift($this->pending)->run($opts->phpunit, $opts->filtered, $env, $opts->passthru, $opts->passthruPhp);
+                if ($opts->verbose) {
+                    $cmd = $this->running[$tokenData['token']];
+                    echo "\nExecuting test via: {$cmd->getLastCommand()}\n";
+                }
             }
         }
     }

--- a/src/Runners/PHPUnit/Worker/BaseWorker.php
+++ b/src/Runners/PHPUnit/Worker/BaseWorker.php
@@ -94,16 +94,20 @@ abstract class BaseWorker
     public function checkNotCrashed()
     {
         if ($this->isCrashed()) {
-            $lastCommand = isset($this->commands) ? ' Last executed command: ' . end($this->commands) : '';
-            throw new \RuntimeException(
-                'This worker has crashed.' . $lastCommand . PHP_EOL
-                . 'Output:' . PHP_EOL
-                . '----------------------' . PHP_EOL
-                . $this->alreadyReadOutput . PHP_EOL
-                . '----------------------' . PHP_EOL
-                . $this->readAllStderr()
-            );
+            throw new \RuntimeException($this->getCrashReport());
         }
+    }
+
+    public function getCrashReport()
+    {
+        $lastCommand = isset($this->commands) ? ' Last executed command: ' . end($this->commands) : '';
+
+        return 'This worker has crashed.' . $lastCommand . PHP_EOL
+            . 'Output:' . PHP_EOL
+            . '----------------------' . PHP_EOL
+            . $this->alreadyReadOutput . PHP_EOL
+            . '----------------------' . PHP_EOL
+            . $this->readAllStderr();
     }
 
     public function stop()

--- a/src/Runners/PHPUnit/Worker/WrapperWorker.php
+++ b/src/Runners/PHPUnit/Worker/WrapperWorker.php
@@ -44,6 +44,7 @@ class WrapperWorker extends BaseWorker
         if ($options->verbose) {
             echo "\nExecuting test via: $command\n";
         }
+        $test->setLastCommand($command);
         $this->execute($command);
     }
 


### PR DESCRIPTION
- Adds logfile output for WrapperRunner by prefixing bin/paratest with PT_LOGGING_ENABLE='true'. 
- Adds docs for logging. 
- Cleans up README.