### PR TITLE
Fix PHPUnitWarningsTest with PHPUnit @dev

### DIFF
--- a/test/fixtures/warning-tests/phpunit.xml.dist
+++ b/test/fixtures/warning-tests/phpunit.xml.dist
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit failOnWarning="true" />

--- a/test/functional/PHPUnitWarningsTest.php
+++ b/test/functional/PHPUnitWarningsTest.php
@@ -11,16 +11,15 @@ class PHPUnitWarningsTest extends FunctionalTestBase
     {
         $proc = $this->invokeParatest(
             'warning-tests/HasWarningsTest.php',
-            ['bootstrap' => BOOTSTRAP]
+            [
+                'bootstrap' => BOOTSTRAP,
+                'configuration' => FIXTURES . DS . 'warning-tests' . DS . 'phpunit.xml.dist',
+            ]
         );
 
         $output = $proc->getOutput();
 
-        $this->assertTrue(version_compare(PHPUnit\Runner\Version::id(), '6.0.0', '>='), 'Expected phpunit 6.0.0+');
-        // PHPUnit 5.1+ Changed how it handles test warnings (not E_WARNINGS)
-        // PHPUnit 6.0 changed it back to non-zero exit code : https://github.com/sebastianbergmann/phpunit/issues/2446
-        // TODO: Does this have any consequences for paratest?
         $this->assertStringContainsString('Warnings', $output, 'Test should output warnings');
-        $this->assertEquals(1, $proc->getExitCode(), 'Test suite should succeed with 0');
+        $this->assertEquals(1, $proc->getExitCode(), 'Test suite should fail with 1');
     }
 }


### PR DESCRIPTION
A PHPUnit bug was fixed to not fail on a warning by default. To test
failures on warnings, define this in the test fixtures XML configuration
file.