### PR TITLE
Add .phpunit.result.cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/fixtures/generated-tests
 nbproject
 .php_cs
 .php_cs.cache
+.phpunit.result.cache


### PR DESCRIPTION
The optional caching of test results that was introduced in PHPUnit 7.3
is now enabled by default in PHPUnit 8. This creates a
.phpunit.result.cache file.