### PR TITLE
Fix functional input option description to match the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options:
                              - Integer (>= 1): Number of processes to run.
                              - auto (default): Number of processes is automatically set to the number of logical CPU cores.
                              - half: Number of processes is automatically set to half the number of logical CPU cores.
- --functional (-f)           Run methods instead of suites in separate processes.
+ --functional (-f)           Run test methods instead of classes in separate processes.
  --no-test-tokens            Disable TEST_TOKEN environment variables. (Default: Variable is set)
  --help (-h)                 Display this help message.
  --coverage-clover           Generate code coverage report in Clover XML format.

--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -40,7 +40,7 @@ class ParaTestCommand extends Command
     {
         $this
             ->addOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 'auto')
-            ->addOption('functional', 'f', InputOption::VALUE_NONE, 'Run methods instead of suites in separate processes.')
+            ->addOption('functional', 'f', InputOption::VALUE_NONE, 'Run test methods instead of classes in separate processes.')
             ->addOption('no-test-tokens', null, InputOption::VALUE_NONE, 'Disable TEST_TOKEN environment variables. <comment>(default: variable is set)</comment>')
             ->addOption('help', 'h', InputOption::VALUE_NONE, 'Display this help message.')
             ->addOption('coverage-clover', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in Clover XML format.')

--- a/test/unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/Console/Commands/ParaTestCommandTest.php
@@ -37,7 +37,7 @@ class ParaTestCommandTest extends \TestBase
     {
         $options = [
             new InputOption('processes', 'p', InputOption::VALUE_REQUIRED, 'The number of test processes to run.', 'auto'),
-            new InputOption('functional', 'f', InputOption::VALUE_NONE, 'Run methods instead of suites in separate processes.'),
+            new InputOption('functional', 'f', InputOption::VALUE_NONE, 'Run test methods instead of classes in separate processes.'),
             new InputOption('help', 'h', InputOption::VALUE_NONE, 'Display this help message.'),
             new InputOption('phpunit', null, InputOption::VALUE_REQUIRED, 'The PHPUnit binary to execute. <comment>(default: vendor/bin/phpunit)</comment>'),
             new InputOption('runner', null, InputOption::VALUE_REQUIRED, 'Runner, WrapperRunner or SqliteRunner. <comment>(default: Runner)</comment>'),


### PR DESCRIPTION
According to README.md functional mode flag differentiates between per-testcase- and per-testmethod-parallelization. Command input option description fixed accordingly.