### PR TITLE
WrapperRunner: proper PHPUNIT_COMPOSER_INSTALL constant initialization

### DIFF
--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -1,13 +1,19 @@
 <?php
 echo "Worker starting\n";
 
-// git working copy
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
-}
-// Composer installation
-if (file_exists(__DIR__ . '/../../../autoload.php')) {
-    require_once __DIR__ . '/../../../autoload.php';
+$composerAutoloadFiles = [
+    __DIR__ . '/../../../autoload.php',
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php'
+];
+
+foreach ($composerAutoloadFiles as $file) {
+    if (file_exists($file)) {
+        require_once $file;
+        define('PHPUNIT_COMPOSER_INSTALL', $file);
+
+        break;
+    }
 }
 
 $commands = fopen('php://stdin', 'r');


### PR DESCRIPTION
## Problem
when I run paratest with enabled [Logging WrapperRunner output](https://github.com/paratestphp/paratest/blob/master/docs/logging.md), I got a strange error:
```
PHPUnit\Framework\Exception: Fatal error: Uncaught Error: Class 'PHPUnit\Util\Configuration' not found in - on line 425

Error: Class 'PHPUnit\Util\Configuration' not found in - on line 425

Call Stack:
    0.0013     549496   1. {main}() -:0
```
## Info
```
phpunit/phpunit: 7.2.0
brianium/paratest: 2.2.0
PHP version: 7.1
```
## How to reproduce
In our project I just followed this documentation: [Logging WrapperRunner output](https://github.com/paratestphp/paratest/blob/master/docs/logging.md) and it always results in the described error.
## Investigation
When the paratest is run with WrapperRunner enabled, the phpunit constant PHPUNIT_COMPOSER_INSTALL is not set. When the code execution reaches the following piece of code in the ```\PHPUnit\Framework\TestCase::run``` https://github.com/sebastianbergmann/phpunit/blob/7.2.0/src/Framework/TestCase.php#L737 :
```php
if (\defined('PHPUNIT_COMPOSER_INSTALL')) {
    $composerAutoload = \var_export(PHPUNIT_COMPOSER_INSTALL, true);
} else {
    $composerAutoload = '\'\'';
}
```
the condition is false. Later, when the template https://github.com/sebastianbergmann/phpunit/blob/7.2.0/src/Util/PHP/Template/TestCaseClass.tpl.dist#L20 is assembled and executed, this piece of code does nothing because the ```$composerAutoload``` is empty:
```php
if ($composerAutoload) {
    require_once $composerAutoload;
    define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
} else if ($phar) {
    require $phar;
}
```
And later this line https://github.com/sebastianbergmann/phpunit/blob/7.2.0/src/Util/PHP/Template/TestCaseClass.tpl.dist#L84 results in the error
```
PHPUnit\Framework\Exception: Fatal error: Uncaught Error: Class 'PHPUnit\Util\Configuration' not found in - on line 425
```
(the exact line in your environment will vary)

## Further thoughts
Would be great if anybody can reproduce and test this PR in their environments. I found this problem in the paratest v2.2.0, but it should be reproducible in the latest version of the praratest.
