### PR TITLE
WrapperRunner: prevent unnecessary output thus allow PHP session

### DIFF
--- a/bin/phpunit-wrapper
+++ b/bin/phpunit-wrapper
@@ -1,5 +1,4 @@
 <?php
-echo "Worker starting\n";
 
 // git working copy
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
@@ -40,7 +39,6 @@ while (true) {
         echo "EXITED\n";
         exit($lastExitCode);
     }
-    echo "Executing: $command\n";
 
     $info = [];
     $info[] = "Time: ".(new \DateTime())->format(DateTime::RFC3339);

--- a/src/Runners/PHPUnit/WrapperRunner.php
+++ b/src/Runners/PHPUnit/WrapperRunner.php
@@ -59,6 +59,7 @@ class WrapperRunner extends BaseRunner
             }
             $worker->start($wrapper, $token, $uniqueToken, [], $this->options);
             $this->streams[] = $worker->stdout();
+            $this->modified[] = $worker->stdout();
             $this->workers[] = $worker;
         }
     }
@@ -69,7 +70,6 @@ class WrapperRunner extends BaseRunner
         $phpunitOptions = $this->options->filtered;
         // $phpunitOptions['no-globals-backup'] = null;  // removed in phpunit 6.0
         while (\count($this->pending)) {
-            $this->waitForStreamsToChange($this->streams);
             foreach ($this->progressedWorkers() as $key => $worker) {
                 if ($worker->isFree()) {
                     try {
@@ -88,6 +88,7 @@ class WrapperRunner extends BaseRunner
                     }
                 }
             }
+            $this->waitForStreamsToChange($this->streams);
         }
     }
 


### PR DESCRIPTION
A possible solution for #377.

I did changes in paratest v2.2.0 (PHP 7.1) and then applied them onto the master branch. I don't have PHP 7.2 environment, so couldn't test it on master.