### PR TITLE
Log the path of the test encountering a fatal error

### DIFF
--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -119,7 +119,7 @@ class Runner extends BaseRunner
             if (!$errorOutput) {
                 $errorOutput = $test->getStdout();
             }
-            throw new \Exception($errorOutput);
+            throw new \Exception(sprintf("Fatal error in %s:\n%s", $test->getPath(), $errorOutput));
         }
         $this->printer->printFeedback($test);
         if ($this->hasCoverage()) {


### PR DESCRIPTION
Before, there was no information on which test caused the fatal error.

After this patch, the output looks like the below (tested by adding an `eval` that caused a fatal error):

```
..S............................................................  63 / 239 ( 26%)
............................................................... 126 / 241 ( 52%)
............SSSSSSSSSS.........................SS.
In Runner.php line 122:
                                                                                                    
  Fatal error in /path/to/paratest/test/functional/PHPUnitTest.php:                  
  Fatal error: A void function must not return a value (did you mean "return;" instead of "return   
  null;"?) in /path/to/paratest/test/WhateverThePHPFileCausingTheCrashWas.php(20) : eval()'d code  
   on line 1                                                                                        
                                                                                                    

paratest [-p|--processes PROCESSES] [-f|--functional] [--no-test-tokens] [-h|--help] [--coverage-clover COVERAGE-CLOVER] [--coverage-html COVERAGE-HTML] [--coverage-php COVERAGE-PHP] [--coverage-text] [--coverage-xml COVERAGE-XML] [-m|--max-batch-size MAX-BATCH-SIZE] [--filter FILTER] [--parallel-suite] [--passthru PASSTHRU] [--passthru-php PASSTHRU-PHP] [-v|--verbose VERBOSE] [--whitelist WHITELIST] [--phpunit PHPUNIT] [--runner RUNNER] [--bootstrap BOOTSTRAP] [-c|--configuration CONFIGURATION] [-g|--group GROUP] [--exclude-group EXCLUDE-GROUP] [--stop-on-failure] [--log-junit LOG-JUNIT] [--colors] [--testsuite [TESTSUITE]] [--path PATH] [--] [<path>]
```