### PR TITLE
Support installing paratest 3.x with php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - BUILD_PHAR=true
+    - php: 7.1
+      env:
+        - PHPUNIT_DEV=true
     - php: 7.2
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "brianium/habitat": "1.0.0",
         "composer/semver": "~1.2",
         "phpunit/php-timer": "^2.0",
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^7.5.8|^8.0",
         "symfony/console": "^3.4|^4.0",
         "symfony/process": "^3.4|^4.0",
         "phpunit/php-code-coverage": "^6.1.4|^7.0.2"

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
 {
     "name": "brianium/paratest",
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
         "brianium/habitat": "1.0.0",
         "composer/semver": "~1.2",
         "phpunit/php-timer": "^2.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^7.0|^8.0",
         "symfony/console": "^3.4|^4.0",
         "symfony/process": "^3.4|^4.0",
-        "phpunit/php-code-coverage": "^7.0.2"
+        "phpunit/php-code-coverage": "^6.1.4|^7.0.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3.2"


### PR DESCRIPTION
PHP 7.1 will continue to receive security support until December 2019,
and some users of paratest would have apps supporting that
(including myself)

- Paratest seems to work with *both* phpunit 7 and phpunit 8
  (e.g. the xml files and the format this is parsing are unchanged)

  I'm assuming there aren't any 2.x backport plans.
- It doesn't seem as if paratest has started using php 7.2's new features

Fixes #389