### PR TITLE
SuiteLoader to use groups from class as well as methods

### DIFF
--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -48,6 +48,7 @@ class ParaTestCommand extends Command
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
             ->addOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.')
             ->addOption('coverage-xml', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in PHPUnit XML format.')
+            ->addOption('coverage-test-limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of tests to record for each line of code. Helps to reduce memory and size of coverage reports.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).')
             ->addOption('parallel-suite', null, InputOption::VALUE_NONE, 'Run the suites of the config in parallel.')

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -159,7 +159,7 @@ abstract class BaseRunner
         if (!isset($this->options->filtered['coverage-php'])) {
             return;
         }
-        $this->coverage = new CoverageMerger();
+        $this->coverage = new CoverageMerger((int)$this->options->coverageTestLimit);
     }
 
     /**

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -134,6 +134,14 @@ class Options
      */
     protected $verbose;
 
+    /**
+     * Limit the number of tests recorded in coverage reports
+     * to avoid them growing too big.
+     *
+     * @var int
+     */
+    protected $coverageTestLimit;
+
     public function __construct(array $opts = [])
     {
         foreach (self::defaults() as $opt => $value) {
@@ -161,6 +169,7 @@ class Options
         $this->passthru = $opts['passthru'] ?? null;
         $this->passthruPhp = $opts['passthru-php'] ?? null;
         $this->verbose = $opts['verbose'] ?? 0;
+        $this->coverageTestLimit = $opts['coverage-test-limit'] ?? 0;
 
         // we need to register that options if they are blank but do not get them as
         // key with null value in $this->filtered as it will create problems for
@@ -231,6 +240,7 @@ class Options
             'passthru' => null,
             'passthru-php' => null,
             'verbose' => 0,
+            'coverage-test-limit' => 0
         ];
     }
 
@@ -292,6 +302,7 @@ class Options
             'passthru' => $this->passthru,
             'passthru-php' => $this->passthruPhp,
             'verbose' => $this->verbose,
+            'coverage-test-limit' => $this->coverageTestLimit
         ]);
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -87,7 +87,7 @@ class SuiteLoader
      *
      * @throws \RuntimeException
      */
-    public function load(string $path = '')
+    public function load(string $path = ''): void
     {
         if ($path) {
             $testFileLoader = new TestFileLoader($this->options);
@@ -134,7 +134,7 @@ class SuiteLoader
      * Called after all files are loaded. Parses loaded files into
      * ExecutableTest objects - either Suite or TestMethod or FullSuite.
      */
-    protected function initSuites()
+    protected function initSuites(): void
     {
         if (\is_array($this->suitesName)) {
             foreach ($this->suitesName as $suiteName) {
@@ -157,7 +157,7 @@ class SuiteLoader
         }
     }
 
-    protected function executableTests(string $path, ParsedClass $class)
+    protected function executableTests(string $path, ParsedClass $class): array
     {
         $executableTests = [];
         $methodBatches = $this->getMethodBatches($class);
@@ -185,7 +185,7 @@ class SuiteLoader
         $maxBatchSize = $this->options && $this->options->functional ? $this->options->maxBatchSize : 0;
         $batches = [];
         foreach ($classMethods as $method) {
-            $tests = $this->getMethodTests($class, $method, $maxBatchSize !== 0);
+            $tests = $this->getMethodTests($class, $method);
             // if filter passed to paratest then method tests can be blank if not match to filter
             if (!$tests) {
                 continue;
@@ -201,7 +201,7 @@ class SuiteLoader
         return $batches;
     }
 
-    protected function addDependentTestsToBatchSet(array &$batches, string $dependsOn, array $tests)
+    protected function addDependentTestsToBatchSet(array &$batches, string $dependsOn, array $tests): void
     {
         foreach ($batches as $key => $batch) {
             foreach ($batch as $methodName) {
@@ -213,7 +213,7 @@ class SuiteLoader
         }
     }
 
-    protected function addTestsToBatchSet(array &$batches, array $tests, int $maxBatchSize)
+    protected function addTestsToBatchSet(array &$batches, array $tests, int $maxBatchSize): void
     {
         foreach ($tests as $test) {
             $lastIndex = \count($batches) - 1;
@@ -233,20 +233,19 @@ class SuiteLoader
      * With empty filter this method returns single test if doesn't have data provider or
      * data provider is not used and return all test if has data provider and data provider is used.
      *
-     * @param ParsedClass  $class           parsed class
-     * @param ParsedObject $method          parsed method
-     * @param bool         $useDataProvider try to use data provider or not
+     * @param ParsedClass  $class  parsed class
+     * @param ParsedObject $method parsed method
      *
      * @return string[] array of test names
      */
-    protected function getMethodTests(ParsedClass $class, ParsedFunction $method, bool $useDataProvider = false): array
+    protected function getMethodTests(ParsedClass $class, ParsedFunction $method): array
     {
         $result = [];
 
         $groups = $this->testGroups($class, $method);
 
         $dataProvider = $this->methodDataProvider($method);
-        if ($useDataProvider && isset($dataProvider)) {
+        if (isset($dataProvider)) {
             $testFullClassName = '\\' . $class->getName();
             $testClass = new $testFullClassName();
             $result = [];
@@ -311,7 +310,7 @@ class SuiteLoader
         return $result;
     }
 
-    protected function testGroups(ParsedClass $class, ParsedFunction $method)
+    protected function testGroups(ParsedClass $class, ParsedFunction $method): array
     {
         return array_merge(
             $this->classGroups($class),
@@ -319,21 +318,25 @@ class SuiteLoader
         );
     }
 
-    protected function methodDataProvider(ParsedFunction $method)
+    protected function methodDataProvider(ParsedFunction $method): ?string
     {
         if (preg_match("/@\bdataProvider\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
             return $matches[1];
         }
+
+        return null;
     }
 
-    protected function methodDependency(ParsedFunction $method)
+    protected function methodDependency(ParsedFunction $method): ?string
     {
         if (preg_match("/@\bdepends\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
             return $matches[1];
         }
+
+        return null;
     }
 
-    protected function methodGroups(ParsedFunction $method)
+    protected function methodGroups(ParsedFunction $method): array
     {
         if (preg_match_all("/@\bgroup\b \b(.*)\b/", $method->getDocBlock(), $matches)) {
             return $matches[1];
@@ -342,7 +345,7 @@ class SuiteLoader
         return [];
     }
 
-    protected function classGroups(ParsedClass $class)
+    protected function classGroups(ParsedClass $class): array
     {
         if (preg_match_all("/@\bgroup\b \b(.*)\b/", $class->getDocBlock(), $matches)) {
             return $matches[1];
@@ -363,7 +366,7 @@ class SuiteLoader
         );
     }
 
-    private function createFullSuite($suiteName, $configPath)
+    private function createFullSuite($suiteName, $configPath): FullSuite
     {
         return new FullSuite($suiteName, $configPath);
     }

--- a/test/fixtures/passing-tests/GroupsTest.php
+++ b/test/fixtures/passing-tests/GroupsTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group group4
+ */
 class GroupsTest extends PHPUnit\FrameWork\TestCase
 {
     /**

--- a/test/unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/Console/Commands/ParaTestCommandTest.php
@@ -56,6 +56,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.'),
             new InputOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.'),
             new InputOption('coverage-xml', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in PHPUnit XML format.'),
+            new InputOption('coverage-test-limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of tests to record for each line of code. Helps to reduce memory and size of coverage reports.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),

--- a/test/unit/Coverage/CoverageMergerTest.php
+++ b/test/unit/Coverage/CoverageMergerTest.php
@@ -65,4 +65,51 @@ class CoverageMergerTest extends \TestBase
         $this->assertCount(1, $data[$secondFile][$secondFileFirstLine]);
         $this->assertEquals('Test1', $data[$secondFile][$secondFileFirstLine][0]);
     }
+
+	/**
+	 * Test merge with limits
+	 *
+	 * @requires function \SebastianBergmann\CodeCoverage\CodeCoverage::merge
+	 */
+	public function testSimpleMergeLimited()
+	{
+		$firstFile = PARATEST_ROOT . '/src/Logging/LogInterpreter.php';
+		$secondFile = PARATEST_ROOT . '/src/Logging/MetaProvider.php';
+
+		// Every time the two above files are changed, the line numbers
+		// may change, and so these two numbers may need adjustments
+		$firstFileFirstLine = 39;
+		$secondFileFirstLine = 39;
+
+		$filter = new Filter();
+		$filter->addFilesToWhitelist([$firstFile, $secondFile]);
+		$coverage1 = new CodeCoverage(null, $filter);
+		$coverage1->append(
+			[
+				$firstFile => [$firstFileFirstLine => 1],
+				$secondFile => [$secondFileFirstLine => 1],
+			],
+			'Test1'
+		);
+		$coverage2 = new CodeCoverage(null, $filter);
+		$coverage2->append(
+			[
+				$firstFile => [$firstFileFirstLine => 1, 1 + $firstFileFirstLine => 1],
+			],
+			'Test2'
+		);
+
+		$merger = new CoverageMerger($test_limit = 1);
+		$this->call($merger, 'addCoverage', $coverage1);
+		$this->call($merger, 'addCoverage', $coverage2);
+
+		/** @var CodeCoverage $coverage */
+		$coverage = $this->getObjectValue($merger, 'coverage');
+
+		$this->assertInstanceOf(CodeCoverage::class, $coverage);
+		$data = $coverage->getData();
+
+		$this->assertCount(1, $data[$firstFile][$firstFileFirstLine]);
+		$this->assertCount(1, $data[$secondFile][$secondFileFirstLine]);
+	}
 }

--- a/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/unit/Runners/PHPUnit/SuiteLoaderTest.php
@@ -285,6 +285,27 @@ class SuiteLoaderTest extends \TestBase
         $this->assertEquals('testFalsehood', $methods[1]->getName());
     }
 
+    public function testGetTestMethodsOnlyReturnsMethodsOfClassGroup()
+    {
+        $options = new Options(['group' => 'group4']);
+        $loader = new SuiteLoader($options);
+        $groupsTest = $this->fixture('passing-tests/GroupsTest.php');
+        $loader->load($groupsTest);
+        $methods = $loader->getTestMethods();
+        $this->assertCount(1, $loader->getSuites());
+        $this->assertCount(5, $methods);
+    }
+
+    public function testGetSuitesForNonMatchingGroups()
+    {
+        $options = new Options(['group' => 'non-existent']);
+        $loader = new SuiteLoader($options);
+        $groupsTest = $this->fixture('passing-tests/GroupsTest.php');
+        $loader->load($groupsTest);
+        $this->assertCount(0, $loader->getSuites());
+        $this->assertCount(0, $loader->getTestMethods());
+    }
+
     public function testLoadIgnoresFilesWithoutClasses()
     {
         $loader = new SuiteLoader();


### PR DESCRIPTION
* Suiteloader was only reading groups from methods instead of both
  classes and methods.

* Reading both of these allows us to filter out suites/test files with
  no matching groups more accurately.