### PR TITLE
Add limit for tests recorded in coverage report

### DIFF
--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -48,6 +48,7 @@ class ParaTestCommand extends Command
             ->addOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.')
             ->addOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.')
             ->addOption('coverage-xml', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in PHPUnit XML format.')
+            ->addOption('coverage-test-limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of tests to record for each line of code. Helps to reduce memory and size of coverage reports.')
             ->addOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).')
             ->addOption('parallel-suite', null, InputOption::VALUE_NONE, 'Run the suites of the config in parallel.')

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -159,7 +159,7 @@ abstract class BaseRunner
         if (!isset($this->options->filtered['coverage-php'])) {
             return;
         }
-        $this->coverage = new CoverageMerger();
+        $this->coverage = new CoverageMerger((int)$this->options->coverageTestLimit);
     }
 
     /**

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -134,6 +134,14 @@ class Options
      */
     protected $verbose;
 
+    /**
+     * Limit the number of tests recorded in coverage reports
+     * to avoid them growing too big.
+     *
+     * @var int
+     */
+    protected $coverageTestLimit;
+
     public function __construct(array $opts = [])
     {
         foreach (self::defaults() as $opt => $value) {
@@ -161,6 +169,7 @@ class Options
         $this->passthru = $opts['passthru'] ?? null;
         $this->passthruPhp = $opts['passthru-php'] ?? null;
         $this->verbose = $opts['verbose'] ?? 0;
+        $this->coverageTestLimit = $opts['coverage-test-limit'] ?? 0;
 
         // we need to register that options if they are blank but do not get them as
         // key with null value in $this->filtered as it will create problems for
@@ -231,6 +240,7 @@ class Options
             'passthru' => null,
             'passthru-php' => null,
             'verbose' => 0,
+            'coverage-test-limit' => 0
         ];
     }
 
@@ -292,6 +302,7 @@ class Options
             'passthru' => $this->passthru,
             'passthru-php' => $this->passthruPhp,
             'verbose' => $this->verbose,
+            'coverage-test-limit' => $this->coverageTestLimit
         ]);
         if ($configuration = $this->getConfigurationPath($filtered)) {
             $filtered['configuration'] = new Configuration($configuration);

--- a/test/unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/unit/Console/Commands/ParaTestCommandTest.php
@@ -56,6 +56,7 @@ class ParaTestCommandTest extends \TestBase
             new InputOption('coverage-php', null, InputOption::VALUE_REQUIRED, 'Serialize PHP_CodeCoverage object to file.'),
             new InputOption('coverage-text', null, InputOption::VALUE_NONE, 'Generate code coverage report in text format.'),
             new InputOption('coverage-xml', null, InputOption::VALUE_REQUIRED, 'Generate code coverage report in PHPUnit XML format.'),
+            new InputOption('coverage-test-limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of tests to record for each line of code. Helps to reduce memory and size of coverage reports.'),
             new InputOption('testsuite', null, InputOption::VALUE_OPTIONAL, 'Filter which testsuite to run'),
             new InputOption('max-batch-size', 'm', InputOption::VALUE_REQUIRED, 'Max batch size (only for functional mode).', 0),
             new InputOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter (only for functional mode).'),

--- a/test/unit/Coverage/CoverageMergerTest.php
+++ b/test/unit/Coverage/CoverageMergerTest.php
@@ -65,4 +65,51 @@ class CoverageMergerTest extends \TestBase
         $this->assertCount(1, $data[$secondFile][$secondFileFirstLine]);
         $this->assertEquals('Test1', $data[$secondFile][$secondFileFirstLine][0]);
     }
+
+	/**
+	 * Test merge with limits
+	 *
+	 * @requires function \SebastianBergmann\CodeCoverage\CodeCoverage::merge
+	 */
+	public function testSimpleMergeLimited()
+	{
+		$firstFile = PARATEST_ROOT . '/src/Logging/LogInterpreter.php';
+		$secondFile = PARATEST_ROOT . '/src/Logging/MetaProvider.php';
+
+		// Every time the two above files are changed, the line numbers
+		// may change, and so these two numbers may need adjustments
+		$firstFileFirstLine = 39;
+		$secondFileFirstLine = 39;
+
+		$filter = new Filter();
+		$filter->addFilesToWhitelist([$firstFile, $secondFile]);
+		$coverage1 = new CodeCoverage(null, $filter);
+		$coverage1->append(
+			[
+				$firstFile => [$firstFileFirstLine => 1],
+				$secondFile => [$secondFileFirstLine => 1],
+			],
+			'Test1'
+		);
+		$coverage2 = new CodeCoverage(null, $filter);
+		$coverage2->append(
+			[
+				$firstFile => [$firstFileFirstLine => 1, 1 + $firstFileFirstLine => 1],
+			],
+			'Test2'
+		);
+
+		$merger = new CoverageMerger($test_limit = 1);
+		$this->call($merger, 'addCoverage', $coverage1);
+		$this->call($merger, 'addCoverage', $coverage2);
+
+		/** @var CodeCoverage $coverage */
+		$coverage = $this->getObjectValue($merger, 'coverage');
+
+		$this->assertInstanceOf(CodeCoverage::class, $coverage);
+		$data = $coverage->getData();
+
+		$this->assertCount(1, $data[$firstFile][$firstFileFirstLine]);
+		$this->assertCount(1, $data[$secondFile][$secondFileFirstLine]);
+	}
 }


### PR DESCRIPTION
* Add limit for the tests recorded in coverage reports, as  these can grow massive if you have many tests which follow common code paths.

* Keeping these limited ensures merging coverage is efficient.