### PR TITLE
Allow iterable data providers

### DIFF
--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -249,8 +249,7 @@ class SuiteLoader
             $testFullClassName = '\\' . $class->getName();
             $testClass = new $testFullClassName();
             $result = [];
-            $datasetKeys = array_keys($testClass->$dataProvider());
-            foreach ($datasetKeys as $key) {
+            foreach ($testClass->$dataProvider() as $key => $value) {
                 $test = sprintf(
                     '%s with data set %s',
                     $method->getName(),

--- a/test/fixtures/dataprovider-tests/DataProviderTest.php
+++ b/test/fixtures/dataprovider-tests/DataProviderTest.php
@@ -56,4 +56,17 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
         return $result;
     }
+
+    /**
+     * @dataProvider dataProviderIterable
+     */
+    public function testIterableDataProvider($expected, $actual)
+    {
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function dataProviderIterable() : iterable
+    {
+        yield from $this->dataProviderNumeric50();
+    }
 }

--- a/test/functional/DataProviderTest.php
+++ b/test/functional/DataProviderTest.php
@@ -22,7 +22,7 @@ class DataProviderTest extends FunctionalTestBase
             'functional' => null,
             'max-batch-size' => 50,
         ]);
-        $this->assertRegExp('/OK \(1100 tests, 1100 assertions\)/', $proc->getOutput());
+        $this->assertRegExp('/OK \(1150 tests, 1150 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSetInFunctionalModeWithMethodFilter()


### PR DESCRIPTION
Data providers aren't always arrays, they can be any iterable (using Generators is a common pattern).