### PR TITLE
#395 Correct warning handling

### DIFF
--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -19,7 +19,7 @@ class Reader extends MetaProvider
     protected $isSingle = false;
 
     /**
-     * @var array
+     * @var TestSuite[]
      */
     protected $suites = [];
 
@@ -101,6 +101,8 @@ class Reader extends MetaProvider
                     $feedback[] = 'E';
                 } elseif ($case->skipped) {
                     $feedback[] = 'S';
+                } elseif ($case->warnings) {
+                    $feedback[] = 'W';
                 } else {
                     $feedback[] = '.';
                 }
@@ -143,7 +145,8 @@ class Reader extends MetaProvider
         if (!$this->isSingle) {
             $this->addSuite($properties, $testCases);
         } else {
-            $this->suites[0]->cases = $testCases;
+            $suite = $this->suites[0];
+            $suite->cases = array_merge($suite->cases, $testCases);
         }
     }
 
@@ -199,11 +202,11 @@ class Reader extends MetaProvider
         $caseNodes = $this->xml->xpath('//testcase');
         $cases = [];
         foreach ($caseNodes as $node) {
-            $case = $node;
-            if (!isset($cases[(string) $node['file']])) {
-                $cases[(string) $node['file']] = [];
+            $caseFilename = (string) $node['file'];
+            if (!isset($cases[$caseFilename])) {
+                $cases[$caseFilename] = [];
             }
-            $cases[(string) $node['file']][] = $node;
+            $cases[$caseFilename][] = $node;
         }
 
         return $cases;

--- a/src/Logging/JUnit/TestCase.php
+++ b/src/Logging/JUnit/TestCase.php
@@ -57,6 +57,13 @@ class TestCase
      */
     public $errors = [];
 
+    /**
+     * List of warnings in this test case.
+     *
+     * @var array
+     */
+    public $warnings = [];
+
     /** @var array */
     public $skipped = [];
 
@@ -100,6 +107,15 @@ class TestCase
     public function addError(string $type, string $text)
     {
         $this->addDefect('errors', $type, $text);
+    }
+
+    /**
+     * @param string $type
+     * @param string $text
+     */
+    public function addWarning(string $type, string $text)
+    {
+        $this->addDefect('warnings', $type, $text);
     }
 
     /**
@@ -169,8 +185,9 @@ class TestCase
 
         $node = self::addSystemOut($node);
         $failures = $node->xpath('failure');
-        $skipped = $node->xpath('skipped');
         $errors = $node->xpath('error');
+        $warnings = $node->xpath('warning');
+        $skipped = $node->xpath('skipped');
 
         foreach ($failures as $fail) {
             $case->addFailure((string) $fail['type'], (string) $fail);
@@ -178,6 +195,10 @@ class TestCase
 
         foreach ($errors as $err) {
             $case->addError((string) $err['type'], (string) $err);
+        }
+
+        foreach ($warnings as $warning) {
+            $case->addWarning((string) $warning['type'], (string) $warning);
         }
 
         foreach ($skipped as $skip) {

--- a/src/Logging/MetaProvider.php
+++ b/src/Logging/MetaProvider.php
@@ -26,7 +26,7 @@ abstract class MetaProvider
      *
      * @var string
      */
-    protected static $messageMethod = '/^get((Failure|Error)s)$/';
+    protected static $messageMethod = '/^get((Failure|Error|Warning)s)$/';
 
     /**
      * Simplify aggregation of totals or messages.

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -103,29 +103,6 @@ abstract class ExecutableTest
     }
 
     /**
-     * Return any warnings that are in the test output, or false if there are none.
-     *
-     * @return mixed
-     */
-    public function getWarnings()
-    {
-        if (!$this->process) {
-            return false;
-        }
-
-        // PHPUnit has a bug where by it doesn't include warnings in the junit
-        // output, but still fails. This is a hacky, imperfect method for extracting them
-        // see https://github.com/sebastianbergmann/phpunit/issues/1317
-        preg_match_all(
-            '/^\d+\) Warning\n(.+?)$/ms',
-            $this->process->getOutput(),
-            $matches
-        );
-
-        return $matches[1] ?? false;
-    }
-
-    /**
      * Stop the process and return it's
      * exit code.
      *

--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -206,7 +206,6 @@ class ResultPrinter
         }
         $this->results->addReader($reader);
         $this->processReaderFeedback($reader, $test->getTestCount());
-        $this->printTestWarnings($test);
     }
 
     /**
@@ -220,20 +219,13 @@ class ResultPrinter
     }
 
     /**
-     * Add an array of warning strings. These cause the test run to be shown
-     * as failed.
-     */
-    public function addWarnings(array $warnings)
-    {
-        $this->warnings = array_merge($this->warnings, $warnings);
-    }
-
-    /**
      * Returns warning messages as a string.
      */
     public function getWarnings(): string
     {
-        return $this->getDefects($this->warnings, 'warning');
+        $warnings = $this->results->getWarnings();
+
+        return $this->getDefects($warnings, 'warning');
     }
 
     /**
@@ -316,22 +308,6 @@ class ResultPrinter
 
         if ($this->processSkipped) {
             $this->printSkippedAndIncomplete($actualTestCount, $expectedTestCount);
-        }
-    }
-
-    /**
-     * Prints test warnings.
-     *
-     * @param ExecutableTest $test
-     */
-    protected function printTestWarnings(ExecutableTest $test)
-    {
-        $warnings = $test->getWarnings();
-        if ($warnings) {
-            $this->addWarnings($warnings);
-            foreach ($warnings as $warning) {
-                $this->printFeedbackItem('W');
-            }
         }
     }
 

--- a/test/fixtures/warning-tests/HasOtherWarningsTest.php
+++ b/test/fixtures/warning-tests/HasOtherWarningsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class HasOtherWarningsTest extends PHPUnit\Framework\TestCase
+{
+    /**
+     * The test will fail on the line that tries to mock the non-existent method
+     *
+     * @return void
+     */
+    public function testMockingNonExistentMethod()
+    {
+        $mock = $this->getMockBuilder(\RuntimeException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock
+            ->method('nonExistentMethodMock')
+            ->will($this->returnValue(true));
+
+        $this->assertTrue(true);
+    }
+}

--- a/test/functional/PHPUnitOtherWarningsTest.php
+++ b/test/functional/PHPUnitOtherWarningsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test special PHPUnit Warnings processing.
+ *
+ * PHPUnit deprecated method calls, mocking non-existent methods and some other cases produce warnings that are output
+ * slightly different. Now the paratest doesn't parse the output directly but relies on the JUnit XML logs.
+ * This test checks whether the parates recognizes those warnings.
+ */
+class PHPUnitOtherWarningsTest extends FunctionalTestBase
+{
+    public function testTestsWithWarningsResultInFailure()
+    {
+        $proc = $this->invokeParatest(
+            'warning-tests/HasOtherWarningsTest.php',
+            [
+                'bootstrap' => BOOTSTRAP,
+                'configuration' => FIXTURES . DS . 'warning-tests' . DS . 'phpunit.xml.dist',
+            ]
+        );
+
+        $output = $proc->getOutput();
+
+        $this->assertStringContainsString('Warnings', $output, 'Test should output warnings');
+        $this->assertEquals(1, $proc->getExitCode(), 'Test suite should fail with 1');
+    }
+}


### PR DESCRIPTION
## Problem
Not all the possible PHPUnit warnings are handled by the paratest correctly and as result:
* the warnings are not seen in the paratest output
* the paratest return code is 0
* although the output contains "FAILURES!"

As an example, when the test method is private, the warning is seen, but in the following cases it is not:
* Using PHPUnit 8 deprecated method call, example: `$this->assertContains("a", "abc");`
* Mocking the class method that doesn't exist in the original class

## Solution
This PR fixes the problem mentioned above. It also fixes #109 correctly. Now the parates doesn't rely on the PHPUnit output in order to parse the warnings, it relies on JUnit XML logging.

This PR might also fix #369 partially. See `src/Logging/JUnit/Reader.php`, line 149:
`$suite->cases = array_merge($suite->cases, $testCases);`

Previously the test cases would be replaced, it can be seen in the debugger if you run the `\PHPUnitWarningsTest::testTestsWithWarningsResultInFailure` test :)
