### PR TITLE
Fixed Symfony 4 deprecated Process constructor

### DIFF
--- a/src/Console/VersionProvider.php
+++ b/src/Console/VersionProvider.php
@@ -41,15 +41,16 @@ final class VersionProvider
 
     public function getGitVersion()
     {
-        $version = null;
+        $cmd = 'git describe --tags --always --first-parent';
+        $process = method_exists(Process::class, 'fromShellCommandline') ?
+            Process::fromShellCommandline($cmd, __DIR__) :
+            new Process($cmd, __DIR__);
 
-        $process = new Process('git describe --tags --always --first-parent', __DIR__);
         if ($process->run() !== 0) {
-            return;
+            return null;
         }
-        $version = trim($process->getOutput());
 
-        return $version;
+        return trim($process->getOutput());
     }
 
     public function getComposerInstalledVersion($package)

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -205,7 +205,11 @@ abstract class ExecutableTest
 
         $this->assertValidCommandLineLength($command);
         $this->setLastCommand($command);
-        $this->process = new Process($command, null, $environmentVariables);
+
+        $this->process = method_exists(Process::class, 'fromShellCommandline') ?
+            Process::fromShellCommandline($command, null, $environmentVariables) :
+            new Process($command, null, $environmentVariables);
+
         if (method_exists($this->process, 'inheritEnvironmentVariables')) {
             $this->process->inheritEnvironmentVariables();  // no such method in 3.0, but emits warning if this isn't done in 3.3
         }

--- a/test/functional/ParaTestInvoker.php
+++ b/test/functional/ParaTestInvoker.php
@@ -28,7 +28,9 @@ class ParaTestInvoker
     {
         $cmd = $this->buildCommand($options);
         $env = defined('PHP_WINDOWS_VERSION_BUILD') ? Habitat::getAll() : null;
-        $proc = new Process($cmd, null, $env, null, $timeout = 600);
+        $proc = method_exists(Process::class, 'fromShellCommandline') ?
+            Process::fromShellCommandline($cmd, null, $env, null, $timeout = 600):
+            new Process($cmd, null, $env, null, $timeout = 600);
         if (method_exists($proc, 'inheritEnvironmentVariables')) {
             $proc->inheritEnvironmentVariables();  // no such method in 3.0, but emits warning if this isn't done in 3.3
         }


### PR DESCRIPTION
This fixes the error:

>"Passing a command as a string when creating a "Symfony\Component\Process\Process" instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the "Process::fromShellCommandline()" constructor
