### PR TITLE
Support multiple TestCase error reports with system out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 composer.lock
+/test/fixtures/generated-tests
+.phpunit.result.cache

--- a/test/Unit/Logging/JUnit/ReaderTest.php
+++ b/test/Unit/Logging/JUnit/ReaderTest.php
@@ -17,11 +17,13 @@ class ReaderTest extends \ParaTest\Tests\TestBase
     public function setUp(): void
     {
         $this->mixedPath = FIXTURES . DS . 'results' . DS . 'mixed-results.xml';
-        $single = FIXTURES . DS . 'results' . DS . 'single-wfailure.xml';
         $this->mixed = new Reader($this->mixedPath);
+        $single = FIXTURES . DS . 'results' . DS . 'single-wfailure.xml';
         $this->single = new Reader($single);
         $empty = FIXTURES . DS . 'results' . DS . 'empty-test-suite.xml';
         $this->empty = new Reader($empty);
+        $multi_errors = FIXTURES . DS . 'results' . DS . 'multiple-errors-with-system-out.xml';
+        $this->multi_errors = new Reader($multi_errors);
     }
 
     public function testInvalidPathThrowsException()
@@ -257,6 +259,29 @@ class ReaderTest extends \ParaTest\Tests\TestBase
             "UnitTestWithMethodAnnotationsTest::testFalsehood\nFailed asserting that true is false.\n\n" .
                 "/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php:18",
             $failures[0]
+        );
+    }
+
+    /**
+     * https://github.com/paratestphp/paratest/issues/352
+     */
+    public function testGetMultiErrorsMessages()
+    {
+        $errors = $this->multi_errors->getErrors();
+        $this->assertCount(2, $errors);
+        $this->assertEquals(
+            "Risky Test\n" .
+            "/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200\n" .
+            "/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159\n" .
+            "Custom error log on result test with multiple errors!",
+            $errors[0]
+        );
+        $this->assertEquals(
+            "Risky Test\n" .
+            "/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200\n" .
+            "/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159\n" .
+            "Custom error log on result test with multiple errors!",
+            $errors[1]
         );
     }
 

--- a/test/fixtures/results/multiple-errors-with-system-out.xml
+++ b/test/fixtures/results/multiple-errors-with-system-out.xml
@@ -1,0 +1,15 @@
+<testsuites>
+  <testsuite name="timeoutTest" file="/project/test/timeoutTest.php" tests="1" assertions="0" errors="2" warnings="0" failures="0" skipped="0" time="1.014721">
+    <testcase name="testTimeoutNotice" class="timeoutTest" classname="timeoutTest" file="/project/test/timeoutTest.php" line="8" assertions="0" time="1.014721">
+      <error type="PHPUnit\Framework\RiskyTestError">Risky Test
+/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200
+/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159
+</error>
+      <error type="PHPUnit\Framework\RiskyTestError">Risky Test
+/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200
+/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159
+</error>
+      <system-out>Custom error log on result test with multiple errors!</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Added handling of phpunit xml output with multiple errors in single testcase.
```xml
<testsuites>
  <testsuite name="timeoutTest" file="/project/test/timeoutTest.php" tests="1" assertions="0" errors="2" warnings="0" failures="0" skipped="0" time="1.014721">
    <testcase name="testTimeoutNotice" class="timeoutTest" classname="timeoutTest" file="/project/test/timeoutTest.php" line="8" assertions="0" time="1.014721">
      <error type="PHPUnit\Framework\RiskyTestError">Risky Test
/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200
/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159
</error>
      <error type="PHPUnit\Framework\RiskyTestError">Risky Test
/project/vendor/phpunit/phpunit/src/TextUI/Command.php:200
/project/vendor/phpunit/phpunit/src/TextUI/Command.php:159
</error>
      <system-out>Custom error log on result test with multiple errors!</system-out>
    </testcase>
  </testsuite>
</testsuites> 
```
fixes #352 

I also added temporary files to .gitignore (they are generated when running tests locally). 

Unfortunately phpunit still don't show correct reason why test stopped in junit output. I will try to find/make issue in phpunit later.