### PR TITLE
Don't call inheritEnvironmentVariables if it's deprecated

### DIFF
--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -192,8 +192,15 @@ abstract class ExecutableTest
             new Process($command, null, $environmentVariables);
 
         if (\method_exists($this->process, 'inheritEnvironmentVariables')) {
-            // no such method in 3.0, but emits warning if this isn't done in 3.3
-            $this->process->inheritEnvironmentVariables();
+            $reflectionMethod = new \ReflectionMethod($this->process, 'inheritEnvironmentVariables');
+            if (\stripos($reflectionMethod->getDocComment() ?: '', '@deprecated') === false) {
+                // no such method in 3.0, but emits warning if this isn't done in 3.3,
+                // and is deprecated starting in symfony/process 4.4 because it became the default.
+                //
+                // This checks for deprecation because E_USER_DEPRECATED may cause problems
+                // in custom error handlers in test bootstrap files
+                $this->process->inheritEnvironmentVariables();
+            }
         }
         $this->process->start();
 


### PR DESCRIPTION
Fixes #417

symfony/process 4.4 is still installed in phpunit 8, because
sebastian/diff only supports symfony/process 4 at the newest.