### PR TITLE
Remove unused dependency on composer/semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "ext-reflection": "*",
         "ext-simplexml": "*",
         "brianium/habitat": "1.0.0",
-        "composer/semver": "~1.2",
         "phpunit/php-timer": "^2.0|^3.0",
         "phpunit/phpunit": "^7.5.8|^8.0|^9.0",
         "symfony/console": "^3.4||^4.0||^5.0",


### PR DESCRIPTION
paratest stopped using it in 7689cde4460bb45162319abd4f1e48ec35c2a3a2

Previously, anything using paratest as a dev dependency would have
composer/semver unexpectedly held back to `~1.2`.
https://github.com/composer/semver/releases includes 1.5.1 and 2.0.