### PR TITLE
Fix deprecation warnings in testsuite to prepare for PhpUnit 10

### DIFF
--- a/test/Functional/Coverage/CoverageMergerTest.php
+++ b/test/Functional/Coverage/CoverageMergerTest.php
@@ -53,7 +53,7 @@ class CoverageMergerTest extends TestBase
         $coverageMerger = new CoverageMerger();
         $coverageMerger->addCoverageFromFile($filename);
 
-        static::assertFileNotExists($filename);
+        static::assertFileDoesNotExist($filename);
     }
 
     /**

--- a/test/Functional/Coverage/CoverageReporterTest.php
+++ b/test/Functional/Coverage/CoverageReporterTest.php
@@ -77,7 +77,7 @@ class CoverageReporterTest extends TestBase
 
         $target = $this->targetDir . '/coverage.php';
 
-        static::assertFileNotExists($target);
+        static::assertFileDoesNotExist($target);
 
         $coverageMerger->getReporter()->php($target);
 
@@ -100,7 +100,7 @@ class CoverageReporterTest extends TestBase
 
         $target = $this->targetDir . '/coverage.xml';
 
-        static::assertFileNotExists($target);
+        static::assertFileDoesNotExist($target);
 
         $coverageMerger->getReporter()->clover($target);
 
@@ -126,7 +126,7 @@ class CoverageReporterTest extends TestBase
 
         $target = $this->targetDir . '/coverage.xml';
 
-        static::assertFileNotExists($target);
+        static::assertFileDoesNotExist($target);
 
         $coverageMerger->getReporter()->crap4j($target);
 
@@ -153,7 +153,7 @@ class CoverageReporterTest extends TestBase
 
         $target = $this->targetDir . '/coverage';
 
-        static::assertFileNotExists($target);
+        static::assertFileDoesNotExist($target);
 
         $coverageMerger->getReporter()->html($target);
 

--- a/test/Functional/DataProviderTest.php
+++ b/test/Functional/DataProviderTest.php
@@ -24,7 +24,7 @@ class DataProviderTest extends FunctionalTestBase
             'functional' => null,
             'max-batch-size' => 50,
         ]);
-        $this->assertRegExp('/OK \(1150 tests, 1150 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(1150 tests, 1150 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSetInFunctionalModeWithMethodFilter()
@@ -34,7 +34,7 @@ class DataProviderTest extends FunctionalTestBase
             'max-batch-size' => 50,
             'filter' => 'testNumericDataProvider50',
         ]);
-        $this->assertRegExp('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSetInFunctionalModeWithCustomFilter()
@@ -44,7 +44,7 @@ class DataProviderTest extends FunctionalTestBase
             'max-batch-size' => 50,
             'filter' => 'testNumericDataProvider50.*1',
         ]);
-        $this->assertRegExp('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
     }
 
     public function testNamedDataSetInFunctionalModeWithMethodFilter()
@@ -54,7 +54,7 @@ class DataProviderTest extends FunctionalTestBase
             'max-batch-size' => 50,
             'filter' => 'testNamedDataProvider50',
         ]);
-        $this->assertRegExp('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(50 tests, 50 assertions\)/', $proc->getOutput());
     }
 
     public function testNamedDataSetInFunctionalModeWithCustomFilter()
@@ -64,7 +64,7 @@ class DataProviderTest extends FunctionalTestBase
             'max-batch-size' => 50,
             'filter' => 'testNamedDataProvider50.*name_of_test_.*1',
         ]);
-        $this->assertRegExp('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(14 tests, 14 assertions\)/', $proc->getOutput());
     }
 
     public function testNumericDataSet1000InFunctionalModeWithFilterAndMaxBatchSize()
@@ -74,6 +74,6 @@ class DataProviderTest extends FunctionalTestBase
             'max-batch-size' => 50,
             'filter' => 'testNumericDataProvider1000',
         ]);
-        $this->assertRegExp('/OK \(1000 tests, 1000 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(1000 tests, 1000 assertions\)/', $proc->getOutput());
     }
 }

--- a/test/Functional/FunctionalTestBase.php
+++ b/test/Functional/FunctionalTestBase.php
@@ -29,7 +29,7 @@ class FunctionalTestBase extends PHPUnit\Framework\TestCase
 
     protected function assertTestsPassed(Process $proc, $testPattern = '\d+', $assertionPattern = '\d+')
     {
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/OK \($testPattern tests?, $assertionPattern assertions?\)/",
             $proc->getOutput()
         );

--- a/test/Functional/GroupTest.php
+++ b/test/Functional/GroupTest.php
@@ -21,37 +21,37 @@ class GroupTest extends FunctionalTestBase
     public function testGroupSwitchOnlyExecutesThoseGroups()
     {
         $proc = $this->invoker->execute(['group' => 'group1']);
-        $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testExcludeGroupSwitchDontExecuteThatGroup()
     {
         $proc = $this->invoker->execute(['exclude-group' => 'group1']);
 
-        $this->assertRegExp('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchExecutesGroupsUsingShortOption()
     {
         $proc = $this->invoker->execute(['g' => 'group1']);
-        $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchOnlyExecutesThoseGroupsInFunctionalMode()
     {
         $proc = $this->invoker->execute(['functional', 'g' => 'group1']);
-        $this->assertRegExp('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(2 tests, 2 assertions\)/', $proc->getOutput());
     }
 
     public function testGroupSwitchOnlyExecutesThoseGroupsWhereTestHasMultipleGroups()
     {
         $proc = $this->invoker->execute(['functional', 'group' => 'group3']);
-        $this->assertRegExp('/OK \(1 test, 1 assertion\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(1 test, 1 assertion\)/', $proc->getOutput());
     }
 
     public function testGroupsSwitchExecutesMultipleGroups()
     {
         $proc = $this->invoker->execute(['functional', 'group' => 'group1,group3']);
-        $this->assertRegExp('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/OK \(3 tests, 3 assertions\)/', $proc->getOutput());
     }
 }

--- a/test/Functional/OutputTest.php
+++ b/test/Functional/OutputTest.php
@@ -25,7 +25,7 @@ class OutputTest extends FunctionalTestBase
         $output = $this->paratest->execute(['p' => 5])->getOutput();
         $this->assertStringContainsString('Running phpunit in 5 processes with ' . PHPUNIT, $output);
         $this->assertStringContainsString('Configuration read from ' . getcwd() . DS . 'phpunit.xml.dist', $output);
-        $this->assertRegExp('/[.F]{4}/', $output);
+        $this->assertMatchesRegularExpression('/[.F]{4}/', $output);
     }
 
     public function testMessagePrintedWhenInvalidConfigFileSupplied()
@@ -43,7 +43,7 @@ class OutputTest extends FunctionalTestBase
             ->getOutput();
         $this->assertStringContainsString('Running phpunit in 5 processes with ' . PHPUNIT, $output);
         $this->assertStringContainsString('Functional mode is ON.', $output);
-        $this->assertRegExp('/[.F]{4}/', $output);
+        $this->assertMatchesRegularExpression('/[.F]{4}/', $output);
     }
 
     public function testProcCountIsReportedWithProcOption()
@@ -51,6 +51,6 @@ class OutputTest extends FunctionalTestBase
         $output = $this->paratest->execute(['p' => 1])
             ->getOutput();
         $this->assertStringContainsString('Running phpunit in 1 process with ' . PHPUNIT, $output);
-        $this->assertRegExp('/[.F]{4}/', $output);
+        $this->assertMatchesRegularExpression('/[.F]{4}/', $output);
     }
 }

--- a/test/Functional/PHPUnitTest.php
+++ b/test/Functional/PHPUnitTest.php
@@ -25,7 +25,7 @@ class PHPUnitTest extends FunctionalTestBase
         $this->assertEquals(1, $proc->getExitCode(), 'Unexpected exit code');
 
         // The [RuntimeException] message appears only on lower 6.x versions of Phpunit
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/(\[RuntimeException\]|Bootstrap specified but could not be found)/',
             $errors,
             'Expected exception name not found in output'
@@ -118,7 +118,7 @@ class PHPUnitTest extends FunctionalTestBase
             'paratest-only-tests/EnvironmentTest.php',
             ['bootstrap' => BOOTSTRAP, 'runner' => 'WrapperRunner', 'no-test-tokens' => 0]
         );
-        $this->assertRegexp('/Failures: 1/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/Failures: 1/', $proc->getOutput());
     }
 
     public function testParatestEnvironmentVariableWithSqliteRunner()
@@ -142,7 +142,7 @@ class PHPUnitTest extends FunctionalTestBase
             'passing-tests',
             ['configuration' => FIXTURES . DS . 'phpunit.xml.disto']
         ); // dist"o" does not exist
-        $this->assertRegExp('/Could not read ".*phpunit.xml.disto"./', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/Could not read ".*phpunit.xml.disto"./', $proc->getOutput());
     }
 
     public function testFunctionalWithBootstrap()
@@ -167,7 +167,7 @@ class PHPUnitTest extends FunctionalTestBase
             'passing-tests',
             ['bootstrap' => BOOTSTRAP, 'processes' => 6]
         );
-        $this->assertRegExp('/Running phpunit in 6 processes/', $proc->getOutput());
+        $this->assertMatchesRegularExpression('/Running phpunit in 6 processes/', $proc->getOutput());
         $this->assertTestsPassed($proc);
     }
 
@@ -295,8 +295,8 @@ class PHPUnitTest extends FunctionalTestBase
         ]);
         $this->assertTestsPassed($proc);
         $results = $proc->getOutput();
-        $this->assertRegExp('/Running phpunit in 6 processes/', $results);
-        $this->assertRegExp('/Functional mode is on/i', $results);
+        $this->assertMatchesRegularExpression('/Running phpunit in 6 processes/', $results);
+        $this->assertMatchesRegularExpression('/Functional mode is on/i', $results);
         $this->assertFileExists($output);
         if (file_exists($output)) {
             unlink($output);

--- a/test/Unit/Console/VersionProviderTest.php
+++ b/test/Unit/Console/VersionProviderTest.php
@@ -33,7 +33,7 @@ class VersionProviderTest extends TestCase
         $this->assertIsString($actual, 'Version of phpunit package was found installed');
 
         // dev-master is included here as the phpunit package is checked and there is a dev-master used on travis
-        $this->assertRegExp("~^dev-master|\d.\d.(.)+$~", $actual, 'Actual version number');
+        $this->assertMatchesRegularExpression("~^dev-master|\d.\d.(.)+$~", $actual, 'Actual version number');
 
         $actual = $provider->getComposerInstalledVersion('foooo/barazzoraz');
         $this->assertNull($actual, 'No version for non-existent package');
@@ -44,6 +44,6 @@ class VersionProviderTest extends TestCase
         $provider = new VersionProvider();
         $actual = $provider->getGitVersion();
         $this->assertIsString($actual, 'Git is enabled and works');
-        $this->assertRegExp("~^\d.\d(?:.\d+)?(?:-\d+-g[\da-f]+)?$~", $actual, 'Git gives a version');
+        $this->assertMatchesRegularExpression("~^\d.\d(?:.\d+)?(?:-\d+-g[\da-f]+)?$~", $actual, 'Git gives a version');
     }
 }

--- a/test/Unit/Logging/JUnit/ReaderTest.php
+++ b/test/Unit/Logging/JUnit/ReaderTest.php
@@ -300,7 +300,7 @@ class ReaderTest extends \ParaTest\Tests\TestBase
         file_put_contents($tmp, $contents);
         $reader = new Reader($tmp);
         $reader->removeLog();
-        $this->assertFileNotExists($tmp);
+        $this->assertFileDoesNotExist($tmp);
     }
 
     /**

--- a/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
@@ -74,7 +74,10 @@ class ExecutableTestTest extends \ParaTest\Tests\TestBase
 
         $command = $this->executableTestChild->command($binary, $options);
         $coverageFileName = str_replace('/', '\/', $this->executableTestChild->getCoverageFileName());
-        $this->assertRegExp("/^'\/usr\/bin\/phpunit' '--a' 'b' '--coverage-php' '$coverageFileName' '.*'/", $command);
+        $this->assertMatchesRegularExpression(
+            "/^'\/usr\/bin\/phpunit' '--a' 'b' '--coverage-php' '$coverageFileName' '.*'/",
+            $command
+        );
     }
 
     public function testHandleEnvironmentVariablesAssignsToken()

--- a/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -165,7 +165,7 @@ class ResultPrinterTest extends ResultTester
 
         $header = $this->printer->getHeader();
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/\n\nTime: ([.:]?[0-9]{1,3})+ ?" .
             '(minute|minutes|second|seconds|ms|)?,' .
             " Memory:[\s][0-9]+([.][0-9]{1,2})? ?M[Bb]\n\n/",


### PR DESCRIPTION
Replaces "assertFileNotExists" with "assertFileDoesNotExist" (1:1 compatible)
Replaces "assertRegExp" with "assertMatchesRegularExpression" (1:1 compatible)

This makes migrating to PHPUnit 10 in the future completely possible.