### PR TITLE
Add --log-teamcity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -g, --group=GROUP                              Only runs tests from the specified group(s).
   -h, --help                                     Display this help message.
       --log-junit=LOG-JUNIT                      Log test execution in JUnit XML format to file.
+      --log-teamcity=LOG-TEAMCITY                Log test execution in Teamcity format to file.
   -m, --max-batch-size=MAX-BATCH-SIZE            Max batch size (only for functional mode). [default: 0]
       --no-test-tokens                           Disable TEST_TOKEN environment variables. (default: variable is set)
       --parallel-suite                           Run the suites of the config in parallel.

--- a/src/Runners/PHPUnit/FullSuite.php
+++ b/src/Runners/PHPUnit/FullSuite.php
@@ -14,9 +14,9 @@ final class FullSuite extends ExecutableTest
     /** @var string */
     private $suiteName;
 
-    public function __construct(string $suiteName, bool $needsCoverage, string $tmpDir)
+    public function __construct(string $suiteName, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct('', $needsCoverage, $tmpDir);
+        parent::__construct('', $needsCoverage, $needsTeamcity, $tmpDir);
 
         $this->suiteName = $suiteName;
     }

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -192,6 +192,8 @@ final class Options
     /** @var string|null */
     private $logJunit;
     /** @var string|null */
+    private $logTeamcity;
+    /** @var string|null */
     private $whitelist;
     /** @var string */
     private $tmpDir;
@@ -222,6 +224,7 @@ final class Options
         bool $functional,
         array $group,
         ?string $logJunit,
+        ?string $logTeamcity,
         ?int $maxBatchSize,
         bool $noTestTokens,
         bool $parallelSuite,
@@ -254,6 +257,7 @@ final class Options
         $this->functional        = $functional;
         $this->group             = $group;
         $this->logJunit          = $logJunit;
+        $this->logTeamcity       = $logTeamcity;
         $this->maxBatchSize      = $maxBatchSize;
         $this->noTestTokens      = $noTestTokens;
         $this->parallelSuite     = $parallelSuite;
@@ -365,6 +369,10 @@ final class Options
             if ($options['log-junit'] === null && $logging->hasJunit()) {
                 $options['log-junit'] = $logging->junit()->target()->path();
             }
+
+            if ($options['log-teamcity'] === null && $logging->hasTeamCity()) {
+                $options['log-teamcity'] = $logging->teamCity()->target()->path();
+            }
         }
 
         if ($configuration !== null) {
@@ -395,6 +403,7 @@ final class Options
             $options['functional'],
             $group,
             $options['log-junit'],
+            $options['log-teamcity'],
             (int) $options['max-batch-size'],
             $options['no-test-tokens'],
             $options['parallel-suite'],
@@ -529,6 +538,12 @@ final class Options
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Log test execution in JUnit XML format to file.'
+            ),
+            new InputOption(
+                'log-teamcity',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Log test execution in Teamcity format to file.'
             ),
             new InputOption(
                 'max-batch-size',
@@ -885,6 +900,16 @@ final class Options
     public function logJunit(): ?string
     {
         return $this->logJunit;
+    }
+
+    public function logTeamcity(): ?string
+    {
+        return $this->logTeamcity;
+    }
+
+    public function hasLogTeamcity(): bool
+    {
+        return $this->logTeamcity !== null;
     }
 
     public function tmpDir(): string

--- a/src/Runners/PHPUnit/Suite.php
+++ b/src/Runners/PHPUnit/Suite.php
@@ -25,9 +25,9 @@ final class Suite extends ExecutableTest
     /**
      * @param TestMethod[] $functions
      */
-    public function __construct(string $path, array $functions, bool $needsCoverage, string $tmpDir)
+    public function __construct(string $path, array $functions, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($path, $needsCoverage, $tmpDir);
+        parent::__construct($path, $needsCoverage, $needsTeamcity, $tmpDir);
         $this->functions = $functions;
     }
 

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -224,6 +224,7 @@ final class SuiteLoader
                 $path,
                 $methodBatch,
                 $this->options->hasCoverage(),
+                $this->options->hasLogTeamcity(),
                 $this->options->tmpDir()
             );
         }
@@ -388,6 +389,7 @@ final class SuiteLoader
                 $class
             ),
             $this->options->hasCoverage(),
+            $this->options->hasLogTeamcity(),
             $this->options->tmpDir()
         );
     }
@@ -397,6 +399,7 @@ final class SuiteLoader
         return new FullSuite(
             $suiteName,
             $this->options->hasCoverage(),
+            $this->options->hasLogTeamcity(),
             $this->options->tmpDir()
         );
     }

--- a/src/Runners/PHPUnit/TestMethod.php
+++ b/src/Runners/PHPUnit/TestMethod.php
@@ -35,9 +35,9 @@ final class TestMethod extends ExecutableTest
      * @param string   $testPath path to phpunit test case file
      * @param string[] $filters  array of filters or single filter
      */
-    public function __construct(string $testPath, array $filters, bool $needsCoverage, string $tmpDir)
+    public function __construct(string $testPath, array $filters, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($testPath, $needsCoverage, $tmpDir);
+        parent::__construct($testPath, $needsCoverage, $needsTeamcity, $tmpDir);
         // for compatibility with other code (tests), which can pass string (one filter)
         // instead of array of filters
         $this->filters = $filters;

--- a/test/Unit/ResultTester.php
+++ b/test/Unit/ResultTester.php
@@ -50,11 +50,12 @@ abstract class ResultTester extends TestBase
     {
         $functions = [];
         for ($i = 0; $i < $methodCount; ++$i) {
-            $functions[] = new TestMethod((string) $i, [], false, TMP_DIR);
+            $functions[] = new TestMethod((string) $i, [], false, true, TMP_DIR);
         }
 
-        $suite = new Suite('', $functions, false, TMP_DIR);
+        $suite = new Suite('', $functions, false, true, TMP_DIR);
         file_put_contents($suite->getTempFile(), (string) file_get_contents(FIXTURES . DS . 'results' . DS . $result));
+        file_put_contents($suite->getTeamcityTempFile(), 'no data');
 
         return $suite;
     }

--- a/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
@@ -21,7 +21,7 @@ final class ExecutableTestTest extends TestBase
 
     public function setUpTest(): void
     {
-        $this->executableTestChild = new ExecutableTestChild('pathToFile', true, TMP_DIR);
+        $this->executableTestChild = new ExecutableTestChild('pathToFile', true, true, TMP_DIR);
     }
 
     public function testConstructor(): void
@@ -47,6 +47,8 @@ final class ExecutableTestTest extends TestBase
             NullPhpunitPrinter::class,
             '--log-junit',
             $this->executableTestChild->getTempFile(),
+            '--log-teamcity',
+            $this->executableTestChild->getTeamcityTempFile(),
             '--coverage-php',
             $this->executableTestChild->getCoverageFileName(),
             'pathToFile',
@@ -59,19 +61,31 @@ final class ExecutableTestTest extends TestBase
     {
         $logFile = $this->executableTestChild->getTempFile();
         static::assertFileExists($logFile);
-        $this->executableTestChild->deleteFile();
+        $this->executableTestChild->deleteTempFiles();
         static::assertFileDoesNotExist($logFile);
 
         $ccFile = $this->executableTestChild->getCoverageFileName();
         static::assertFileExists($ccFile);
-        $this->executableTestChild->deleteFile();
+        $this->executableTestChild->deleteTempFiles();
         static::assertFileDoesNotExist($ccFile);
+
+        $tfFile = $this->executableTestChild->getTeamcityTempFile();
+        static::assertFileExists($tfFile);
+        $this->executableTestChild->deleteTempFiles();
+        static::assertFileDoesNotExist($tfFile);
     }
 
     public function testGetTempFileShouldReturnSameFileIfAlreadyCalled(): void
     {
         $file      = $this->executableTestChild->getTempFile();
         $fileAgain = $this->executableTestChild->getTempFile();
+        static::assertEquals($file, $fileAgain);
+    }
+
+    public function testGetTeamcityTempFileShouldReturnSameFileIfAlreadyCalled(): void
+    {
+        $file      = $this->executableTestChild->getTeamcityTempFile();
+        $fileAgain = $this->executableTestChild->getTeamcityTempFile();
         static::assertEquals($file, $fileAgain);
     }
 

--- a/test/Unit/Runners/PHPUnit/FullSuiteTest.php
+++ b/test/Unit/Runners/PHPUnit/FullSuiteTest.php
@@ -19,7 +19,7 @@ final class FullSuiteTest extends TestBase
     public function testPrepareTheFullSuiteAsArguments(): void
     {
         $name      = uniqid('Suite_');
-        $fullSuite = new FullSuite($name, false, TMP_DIR);
+        $fullSuite = new FullSuite($name, false, false, TMP_DIR);
 
         $commandArguments = $fullSuite->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -228,6 +228,7 @@ final class OptionsTest extends TestBase
             '--functional' => true,
             '--group' => 'GROUP',
             '--log-junit' => 'LOG-JUNIT',
+            '--log-teamcity' => 'LOG-TEAMCITY',
             '--max-batch-size' => 5,
             '--no-test-tokens' => true,
             '--parallel-suite' => true,
@@ -261,6 +262,7 @@ final class OptionsTest extends TestBase
         static::assertTrue($options->functional());
         static::assertSame(['GROUP'], $options->group());
         static::assertSame('LOG-JUNIT', $options->logJunit());
+        static::assertSame('LOG-TEAMCITY', $options->logTeamcity());
         static::assertSame(5, $options->maxBatchSize());
         static::assertTrue($options->noTestTokens());
         static::assertTrue($options->parallelSuite());
@@ -284,6 +286,7 @@ final class OptionsTest extends TestBase
             'whitelist' => 'WHITELIST',
         ], $options->filtered());
 
+        static::assertTrue($options->hasLogTeamcity());
         static::assertTrue($options->hasCoverage());
     }
 

--- a/test/Unit/Runners/PHPUnit/SuiteTest.php
+++ b/test/Unit/Runners/PHPUnit/SuiteTest.php
@@ -20,10 +20,10 @@ final class SuiteTest extends TestBase
     public function testConstructor(): void
     {
         $file        = uniqid('pathToFile_');
-        $testMethod1 = new TestMethod($file, [], false, TMP_DIR);
-        $testMethod2 = new TestMethod($file, [], false, TMP_DIR);
+        $testMethod1 = new TestMethod($file, [], false, false, TMP_DIR);
+        $testMethod2 = new TestMethod($file, [], false, false, TMP_DIR);
         $testMethods = [$testMethod1, $testMethod2];
-        $suite       = new Suite($file, $testMethods, false, TMP_DIR);
+        $suite       = new Suite($file, $testMethods, false, false, TMP_DIR);
 
         $commandArguments = $suite->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/TestMethodTest.php
+++ b/test/Unit/Runners/PHPUnit/TestMethodTest.php
@@ -19,7 +19,7 @@ final class TestMethodTest extends TestBase
     public function testConstructor(): void
     {
         $file       = uniqid('pathToFile_');
-        $testMethod = new TestMethod($file, ['method1', 'method2'], false, TMP_DIR);
+        $testMethod = new TestMethod($file, ['method1', 'method2'], false, false, TMP_DIR);
 
         $commandArguments = $testMethod->commandArguments(uniqid(), [], null);
 


### PR DESCRIPTION
In our project we need `phpunit` reporting in Teamcity format. This is not possible, because `paratest `merges test execution result and reports them in human-readable form.

However, Teamcity can manage test results by itself. So, we can use `log-teamcity` option of `phpunit` and see sorted/merged results in Teamcity.

This PR relates to this issue too: #265 