### PR TITLE
Fix phpunit-wrapper from resetting variables in global scope in WrapperRunner

### DIFF
--- a/bin/phpunit-wrapper.php
+++ b/bin/phpunit-wrapper.php
@@ -2,39 +2,41 @@
 
 declare(strict_types=1);
 
-$opts = getopt('', [
-    'write-to:',
-]);
+function phpunitWrapperMain(): void {
 
-$composerAutoloadFiles = [
+  $opts = getopt('', [
+    'write-to:',
+  ]);
+
+  $composerAutoloadFiles = [
     dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'autoload.php',
     dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
     dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
-];
+  ];
 
-foreach ($composerAutoloadFiles as $file) {
+  foreach ($composerAutoloadFiles as $file) {
     if (file_exists($file)) {
-        require_once $file;
-        define('PHPUNIT_COMPOSER_INSTALL', $file);
+      require_once $file;
+      define('PHPUNIT_COMPOSER_INSTALL', $file);
 
-        break;
+      break;
     }
-}
+  }
 
-assert(is_string($opts['write-to']));
-$writeTo = fopen($opts['write-to'], 'wb');
-assert(is_resource($writeTo));
+  assert(is_string($opts['write-to']));
+  $writeTo = fopen($opts['write-to'], 'wb');
+  assert(is_resource($writeTo));
 
-$i = 0;
-while (true) {
+  $i = 0;
+  while (true) {
     $i++;
     if (feof(\STDIN)) {
-        exit;
+      exit;
     }
 
     $command = fgets(\STDIN);
     if ($command === false || $command === \ParaTest\Runners\PHPUnit\Worker\WrapperWorker::COMMAND_EXIT) {
-        exit;
+      exit;
     }
 
     $arguments = unserialize($command);
@@ -42,4 +44,7 @@ while (true) {
 
     fwrite($writeTo, \ParaTest\Runners\PHPUnit\Worker\WrapperWorker::TEST_EXECUTED_MARKER);
     fflush($writeTo);
+  }
 }
+
+phpunitWrapperMain();

--- a/bin/phpunit-wrapper.php
+++ b/bin/phpunit-wrapper.php
@@ -2,49 +2,46 @@
 
 declare(strict_types=1);
 
-function phpunitWrapperMain(): void {
+use ParaTest\Runners\PHPUnit\Worker\WrapperWorker;
 
-  $opts = getopt('', [
-    'write-to:',
-  ]);
+(static function (): void {
+    $opts = getopt('', ['write-to:']);
 
-  $composerAutoloadFiles = [
-    dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'autoload.php',
-    dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
-    dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
-  ];
+    $composerAutoloadFiles = [
+        dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'autoload.php',
+        dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+        dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+    ];
 
-  foreach ($composerAutoloadFiles as $file) {
-    if (file_exists($file)) {
-      require_once $file;
-      define('PHPUNIT_COMPOSER_INSTALL', $file);
+    foreach ($composerAutoloadFiles as $file) {
+        if (file_exists($file)) {
+            require_once $file;
+            define('PHPUNIT_COMPOSER_INSTALL', $file);
 
-      break;
-    }
-  }
-
-  assert(is_string($opts['write-to']));
-  $writeTo = fopen($opts['write-to'], 'wb');
-  assert(is_resource($writeTo));
-
-  $i = 0;
-  while (true) {
-    $i++;
-    if (feof(\STDIN)) {
-      exit;
+            break;
+        }
     }
 
-    $command = fgets(\STDIN);
-    if ($command === false || $command === \ParaTest\Runners\PHPUnit\Worker\WrapperWorker::COMMAND_EXIT) {
-      exit;
+    assert(is_string($opts['write-to']));
+    $writeTo = fopen($opts['write-to'], 'wb');
+    assert(is_resource($writeTo));
+
+    $i = 0;
+    while (true) {
+        $i++;
+        if (feof(STDIN)) {
+            exit;
+        }
+
+        $command = fgets(STDIN);
+        if ($command === false || $command === WrapperWorker::COMMAND_EXIT) {
+            exit;
+        }
+
+        $arguments = unserialize($command);
+        (new PHPUnit\TextUI\Command())->run($arguments, false);
+
+        fwrite($writeTo, WrapperWorker::TEST_EXECUTED_MARKER);
+        fflush($writeTo);
     }
-
-    $arguments = unserialize($command);
-    (new PHPUnit\TextUI\Command)->run($arguments, false);
-
-    fwrite($writeTo, \ParaTest\Runners\PHPUnit\Worker\WrapperWorker::TEST_EXECUTED_MARKER);
-    fflush($writeTo);
-  }
-}
-
-phpunitWrapperMain();
+})();

--- a/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
@@ -29,4 +29,16 @@ final class WrapperRunnerTest extends RunnerTestCase
 
         $this->runRunner();
     }
+
+    /**
+     * @see github.com/paratestphp/paratest/pull/540
+     * we test that everything is okey with few tests
+     * was problem that phpunit reset global variables in phpunit-wrapper, and tests fails
+     */
+    public function testWrapperRunnerWorksWellWithManyTests(): void
+    {
+        $this->bareOptions['--path'] = $this->fixture('passing_tests' . DS . 'level1' . DS . 'level2');
+
+        $this->runRunner();
+    }
 }

--- a/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
@@ -30,14 +30,15 @@ final class WrapperRunnerTest extends RunnerTestCase
         $this->runRunner();
     }
 
-    /**
-     * @see github.com/paratestphp/paratest/pull/540
-     * we test that everything is okey with few tests
-     * was problem that phpunit reset global variables in phpunit-wrapper, and tests fails
-     */
+  /**
+   * @see github.com/paratestphp/paratest/pull/540
+   * we test that everything is okey with few tests
+   * was problem that phpunit reset global variables in phpunit-wrapper, and tests fails
+   */
     public function testWrapperRunnerWorksWellWithManyTests(): void
     {
-        $this->bareOptions['--path'] = $this->fixture('passing_tests' . DS . 'level1' . DS . 'level2');
+        $this->bareOptions['--path']          = $this->fixture('passing_tests' . DS . 'level1' . DS . 'level2');
+        $this->bareOptions['--configuration'] = $this->bareOptions['--configuration']  = $this->fixture('phpunit-parallel-suite-with-globals.xml');
 
         $this->runRunner();
     }

--- a/test/fixtures/phpunit-parallel-suite-with-globals.xml
+++ b/test/fixtures/phpunit-parallel-suite-with-globals.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" backupGlobals="true">
+    <testsuites>
+        <testsuite name="Suite 1">
+            <directory>./parallel_suite/One/</directory>
+        </testsuite>
+        <testsuite name="Suite 2">
+            <directory>./parallel_suite/Two/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
phpunit-wrapper has a problem

it's broken in WrapperRunner
phpunit reset global variables between runs
https://phpunit.readthedocs.io/en/9.3/fixtures.html#global-state

I've got problems with global state in phpunit and this fix helped me.
I tried to user WrapperRunner in my big project, and this helps

this fix prevent variables in phpwrapper (they all in global scope) from turning to null 

(Also I removed assert here like in #539, I need this for passing all tests)