### PR TITLE
Add support of env variable RANDOM_ORDER_SEED

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -112,18 +112,21 @@ parameters:
             count: 1
             path: test/fixtures/wrapper_runner_exit_code_tests/FailureTest.php
         -
-            message: "#^Offset 'TEST_TOKEN' does not exist on array\\('PARATEST' \\=\\> 1, \\?'TEST_TOKEN' \\=\\> int, \\?'UNIQUE_TEST_TOKEN' \\=\\> string\\)\\.$#"
+            message: "#^Offset 'TEST_TOKEN' does not exist on array\\('PARATEST' \\=\\> 1, \\?'RANDOM_ORDER_SEED' \\=\\> int, \\?'TEST_TOKEN' \\=\\> int, \\?'UNIQUE_TEST_TOKEN' \\=\\> string\\)\\.$#"
             count: 1
             path: test/Unit/Runners/PHPUnit/OptionsTest.php
+        -
+             message: "#^Offset 'RANDOM_ORDER_SEED' does not exist on array\\('PARATEST' \\=\\> 1, \\'TEST_TOKEN' \\=\\> int, \\?'RANDOM_ORDER_SEED' \\=\\> int, \\'UNIQUE_TEST_TOKEN' \\=\\> string\\)\\.$#"
+             count: 1
+             path: test/Unit/Runners/PHPUnit/OptionsTest.php
+        -
+             message: "#^Offset 'UNIQUE_TEST_TOKEN' does not exist on array\\('PARATEST' \\=\\> 1, \\?'RANDOM_ORDER_SEED' \\=\\> int, \\?'UNIQUE_TEST_TOKEN' \\=\\> string, 'TEST_TOKEN' \\=\\> int\\)\\.$#"
+             count: 1
+             path: test/Unit/Runners/PHPUnit/OptionsTest.php
         -
             message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsString\\(\\) with string will always evaluate to true\\.$#"
             count: 1
             path: test/Unit/Runners/PHPUnit/OptionsTest.php
-        -
-            message: "#^Offset 'UNIQUE_TEST_TOKEN' does not exist on array\\('PARATEST' \\=\\> 1, \\?'UNIQUE_TEST_TOKEN' \\=\\> string, 'TEST_TOKEN' \\=\\> int\\)\\.$#"
-            count: 1
-            path: test/Unit/Runners/PHPUnit/OptionsTest.php
-
         # Level 7
         -
             message: "#^Method ParaTest\\\\Tests\\\\Unit\\\\Runners\\\\PHPUnit\\\\SuiteLoaderTest\\:\\:getLoadedPaths\\(\\) should return array\\<string\\> but returns array\\<int, int\\|string\\>\\.$#"


### PR DESCRIPTION
I really need to pass Env variable RANDOM_ORDER_SEED to paratest and to test cases.
This allow me to pass by env variable RANDOM_ORDER_SEED to paratest and phpunit.
By this fix, I will mock random functions , and they will be depend on randomseed

for example
export RANDOM_ORDER_SEED=$(date +%s) 
./vendor/bin/paratest --order-by=random

in testcase

function test_randomTest() {
   $this->mock('randomChanse')->willReturnCallback(func() {
       mt_srand(getenv('RANDOM_ORDER_SEED') ?: 123);
       return mt_rand(1, 100500);
 }

availability to use the same seed for test and shuffle give possibility to reproduce any random tests

also it very useful to pass int from env, not from param