### PR TITLE
readme: mention caveat of sharing constants between test classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ if (getenv('TEST_TOKEN') !== false) {  // Using paratest
 }
 ```
 
+# Caveats
+
+- Constants exposed by test classes consumed by other test classes are not supported
+  This is due to a limitation of the current implementation of `WrapperRunner` and how PHPUnit searches for classes. The fix is put the constants into classes which are not tests _themselves_.
+
 # For Contributors: Testing paratest itself
 
 **Note that The `display_errors` php.ini directive must be set to `stderr` to run the test suite.**

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ if (getenv('TEST_TOKEN') !== false) {  // Using paratest
 
 # Caveats
 
-- Constants exposed by test classes consumed by other test classes are not supported
-  This is due to a limitation of the current implementation of `WrapperRunner` and how PHPUnit searches for classes. The fix is put the constants into classes which are not tests _themselves_.
+1. Constants exposed by test classes consumed by other test classes are not supported. This is due to a limitation of the current implementation of `WrapperRunner` and how PHPUnit searches for classes. The fix is put the constants into classes which are not tests _themselves_.
 
 # For Contributors: Testing paratest itself
 


### PR DESCRIPTION
See https://github.com/paratestphp/paratest/issues/568