### PR TITLE
Add support for no-coverage option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -191,8 +191,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
+          key: recache1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: recache1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -191,8 +191,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: recache1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: recache1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -135,12 +135,17 @@ parameters:
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#21 \\$noTestTokens of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#21 \\$noCoverage of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#22 \\$parallelSuite of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#22 \\$noTestTokens of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Runners/PHPUnit/Options.php
+
+		-
+			message: "#^Parameter \\#23 \\$parallelSuite of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
@@ -150,37 +155,37 @@ parameters:
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#25 \\$path of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#26 \\$path of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#27 \\$processes of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects int, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#28 \\$processes of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects int, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#28 \\$runner of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#29 \\$runner of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#29 \\$stopOnFailure of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#30 \\$stopOnFailure of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#31 \\$tmpDir of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#32 \\$tmpDir of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#33 \\$whitelist of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#34 \\$whitelist of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#34 \\$orderBy of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string given\\.$#"
+			message: "#^Parameter \\#35 \\$orderBy of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string, array\\<string\\>\\|bool\\|int\\|string given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -1045,11 +1045,6 @@ final class Options
         return $this->coverageXml;
     }
 
-    public function noCoverage(): bool
-    {
-        return $this->noCoverage;
-    }
-
     public function cwd(): string
     {
         return $this->cwd;

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -203,6 +203,8 @@ final class Options
     private $coverageText;
     /** @var string|null */
     private $coverageXml;
+    /** @var bool */
+    private $noCoverage;
     /** @var string */
     private $cwd;
     /** @var string|null */
@@ -247,6 +249,7 @@ final class Options
         ?string $logJunit,
         ?string $logTeamcity,
         ?int $maxBatchSize,
+        bool $noCoverage,
         bool $noTestTokens,
         bool $parallelSuite,
         ?array $passthru,
@@ -283,6 +286,7 @@ final class Options
         $this->logJunit          = $logJunit;
         $this->logTeamcity       = $logTeamcity;
         $this->maxBatchSize      = $maxBatchSize;
+        $this->noCoverage        = $noCoverage;
         $this->noTestTokens      = $noTestTokens;
         $this->parallelSuite     = $parallelSuite;
         $this->passthru          = $passthru;
@@ -319,6 +323,7 @@ final class Options
         assert(is_bool($options['functional']));
         assert($options['log-junit'] === null || is_string($options['log-junit']));
         assert($options['log-teamcity'] === null || is_string($options['log-teamcity']));
+        assert(is_bool($options['no-coverage']));
         assert(is_bool($options['no-test-tokens']));
         assert($options['order-by'] === null || is_string($options['order-by']));
         assert(is_bool($options['parallel-suite']));
@@ -516,6 +521,7 @@ final class Options
             $options['log-junit'],
             $options['log-teamcity'],
             (int) $options['max-batch-size'],
+            $options['no-coverage'],
             $options['no-test-tokens'],
             $options['parallel-suite'],
             self::parsePassthru($options['passthru']),
@@ -536,6 +542,10 @@ final class Options
 
     public function hasCoverage(): bool
     {
+        if ($this->noCoverage) {
+            return false;
+        }
+
         return $this->coverageClover !== null
             || $this->coverageCobertura !== null
             || $this->coverageCrap4j !== null
@@ -671,6 +681,12 @@ final class Options
                 InputOption::VALUE_REQUIRED,
                 'Max batch size (only for functional mode).',
                 0
+            ),
+            new InputOption(
+                'no-coverage',
+                null,
+                InputOption::VALUE_NONE,
+                'Ignore code coverage configuration.'
             ),
             new InputOption(
                 'no-test-tokens',
@@ -1027,6 +1043,11 @@ final class Options
     public function coverageXml(): ?string
     {
         return $this->coverageXml;
+    }
+
+    public function noCoverage(): bool
+    {
+        return $this->noCoverage;
     }
 
     public function cwd(): string

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -232,7 +232,6 @@ final class OptionsTest extends TestBase
         static::assertSame(0, $options->coverageTestLimit());
         static::assertFalse($options->coverageText());
         static::assertNull($options->coverageXml());
-        static::assertFalse($options->noCoverage());
         static::assertSame(__DIR__, $options->cwd());
         static::assertEmpty($options->excludeGroup());
         static::assertNull($options->filter());
@@ -276,7 +275,6 @@ final class OptionsTest extends TestBase
             '--coverage-test-limit' => 3,
             '--coverage-text' => true,
             '--coverage-xml' => 'COVERAGE-XML',
-            '--no-coverage' => true,
             '--exclude-group' => 'EXCLUDE-GROUP',
             '--filter' => 'FILTER',
             '--functional' => true,
@@ -313,7 +311,6 @@ final class OptionsTest extends TestBase
         static::assertSame(3, $options->coverageTestLimit());
         static::assertTrue($options->coverageText());
         static::assertSame('COVERAGE-XML', $options->coverageXml());
-        static::assertTrue($options->noCoverage());
         static::assertSame(__DIR__, $options->cwd());
         static::assertSame(['EXCLUDE-GROUP'], $options->excludeGroup());
         static::assertSame('FILTER', $options->filter());
@@ -349,7 +346,7 @@ final class OptionsTest extends TestBase
         ], $options->filtered());
 
         static::assertTrue($options->hasLogTeamcity());
-        static::assertFalse($options->hasCoverage());
+        static::assertTrue($options->hasCoverage());
     }
 
     public function testSingleVerboseFlag(): void
@@ -387,7 +384,25 @@ final class OptionsTest extends TestBase
         static::assertTrue($options->hasCoverage());
     }
 
-    public function testNoCoverageOptionDisablesCoverage(): void
+    public function testNoCoverageOptionDisablesCoverageOptions(): void
+    {
+        $argv = [
+            '--coverage-clover' => 'COVERAGE-CLOVER',
+            '--coverage-cobertura' => 'COVERAGE-COBERTURA',
+            '--coverage-crap4j' => 'COVERAGE-CRAP4J',
+            '--coverage-html' => 'COVERAGE-HTML',
+            '--coverage-php' => 'COVERAGE-PHP',
+            '--coverage-text' => true,
+            '--coverage-xml' => 'COVERAGE-XML',
+            '--no-coverage' => true,
+        ];
+
+        $options = $this->createOptionsFromArgv($argv, __DIR__);
+
+        static::assertFalse($options->hasCoverage());
+    }
+
+    public function testNoCoverageOptionDisablesCoverageConfiguration(): void
     {
         $argv = [
             '--configuration' => $this->fixture('phpunit-fully-configured.xml'),

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -232,6 +232,7 @@ final class OptionsTest extends TestBase
         static::assertSame(0, $options->coverageTestLimit());
         static::assertFalse($options->coverageText());
         static::assertNull($options->coverageXml());
+        static::assertFalse($options->noCoverage());
         static::assertSame(__DIR__, $options->cwd());
         static::assertEmpty($options->excludeGroup());
         static::assertNull($options->filter());
@@ -275,6 +276,7 @@ final class OptionsTest extends TestBase
             '--coverage-test-limit' => 3,
             '--coverage-text' => true,
             '--coverage-xml' => 'COVERAGE-XML',
+            '--no-coverage' => true,
             '--exclude-group' => 'EXCLUDE-GROUP',
             '--filter' => 'FILTER',
             '--functional' => true,
@@ -311,6 +313,7 @@ final class OptionsTest extends TestBase
         static::assertSame(3, $options->coverageTestLimit());
         static::assertTrue($options->coverageText());
         static::assertSame('COVERAGE-XML', $options->coverageXml());
+        static::assertTrue($options->noCoverage());
         static::assertSame(__DIR__, $options->cwd());
         static::assertSame(['EXCLUDE-GROUP'], $options->excludeGroup());
         static::assertSame('FILTER', $options->filter());
@@ -346,7 +349,7 @@ final class OptionsTest extends TestBase
         ], $options->filtered());
 
         static::assertTrue($options->hasLogTeamcity());
-        static::assertTrue($options->hasCoverage());
+        static::assertFalse($options->hasCoverage());
     }
 
     public function testSingleVerboseFlag(): void
@@ -382,6 +385,18 @@ final class OptionsTest extends TestBase
         static::assertStringContainsString('junit.xml', $options->logJunit());
 
         static::assertTrue($options->hasCoverage());
+    }
+
+    public function testNoCoverageOptionDisablesCoverage(): void
+    {
+        $argv = [
+            '--configuration' => $this->fixture('phpunit-fully-configured.xml'),
+            '--no-coverage' => true,
+        ];
+
+        $options = $this->createOptionsFromArgv($argv, __DIR__);
+
+        static::assertFalse($options->hasCoverage());
     }
 
     public function testFillEnvWithTokens(): void


### PR DESCRIPTION
This PR makes possible to use a `--no-coverage` option which make paratest ignore coverage configuration.

It is useful to ignore coverage configuration defined in xml configuration, for example if there are no coverage driver available.