### PR TITLE
Use a wrapper test suite to avoid TestSuiteLoader problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Why use `paratest` over the alternative parallel test runners out there?
 To install with composer run the following command:
 
     composer require --dev brianium/paratest
-    
+
 # Versions
 
 Only the latest version of PHPUnit is supported, and thus only the latest version of ParaTest is actively maintained.
@@ -140,7 +140,7 @@ Code Coverage Report:
   Lines:   59.38% (896/1509)
 ````
 
-**Caution**: Generating coverage is an art in itself. Please refer to our extensive guide on setting up everything correctly for 
+**Caution**: Generating coverage is an art in itself. Please refer to our extensive guide on setting up everything correctly for
 [code coverage generation with `paratest`](docs/code-coverage.md).
 
 ### Windows
@@ -189,10 +189,6 @@ if (getenv('TEST_TOKEN') !== false) {  // Using paratest
     $dbname = 'testdb';
 }
 ```
-
-# Caveats
-
-1. Constants, static methods, static variables and everything exposed by test classes consumed by other test classes (including Reflection) are not supported. This is due to a limitation of the current implementation of `WrapperRunner` and how PHPUnit searches for classes. The fix is put shared code into classes which are not tests _themselves_.
 
 # For Contributors: Testing paratest itself
 

--- a/src/Runners/PHPUnit/FullSuite.php
+++ b/src/Runners/PHPUnit/FullSuite.php
@@ -16,7 +16,7 @@ final class FullSuite extends ExecutableTest
 
     public function __construct(string $suiteName, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct('', $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct('', '', $needsCoverage, $needsTeamcity, $tmpDir);
 
         $this->suiteName = $suiteName;
     }

--- a/src/Runners/PHPUnit/Suite.php
+++ b/src/Runners/PHPUnit/Suite.php
@@ -25,9 +25,9 @@ final class Suite extends ExecutableTest
     /**
      * @param TestMethod[] $functions
      */
-    public function __construct(string $path, array $functions, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
+    public function __construct(string $path, string $class, array $functions, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($path, $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct($path, $class, $needsCoverage, $needsTeamcity, $tmpDir);
         $this->functions = $functions;
     }
 

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -224,6 +224,7 @@ final class SuiteLoader
         foreach ($methodBatches as $methodBatch) {
             $executableTests[] = new TestMethod(
                 $path,
+                $class->getName(),
                 $methodBatch,
                 $this->options->hasCoverage(),
                 $this->options->hasLogTeamcity(),
@@ -388,6 +389,7 @@ final class SuiteLoader
     {
         return new Suite(
             $path,
+            $class->getName(),
             $this->executableTests(
                 $path,
                 $class

--- a/src/Runners/PHPUnit/TestMethod.php
+++ b/src/Runners/PHPUnit/TestMethod.php
@@ -35,9 +35,9 @@ final class TestMethod extends ExecutableTest
      * @param string   $testPath path to phpunit test case file
      * @param string[] $filters  array of filters or single filter
      */
-    public function __construct(string $testPath, array $filters, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
+    public function __construct(string $testPath, string $class, array $filters, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($testPath, $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct($testPath, $class, $needsCoverage, $needsTeamcity, $tmpDir);
         // for compatibility with other code (tests), which can pass string (one filter)
         // instead of array of filters
         $this->filters = $filters;

--- a/src/Runners/PHPUnit/Worker/WrapperWorker.php
+++ b/src/Runners/PHPUnit/Worker/WrapperWorker.php
@@ -130,7 +130,7 @@ final class WrapperWorker
     public function assign(ExecutableTest $test, string $phpunit, array $phpunitOptions, Options $options): void
     {
         assert($this->currentlyExecuting === null);
-        $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru());
+        $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru(), true);
         $command          = implode(' ', array_map('\\escapeshellarg', $commandArguments));
         if ($options->verbosity() >= Options::VERBOSITY_VERY_VERBOSE) {
             $this->output->write("\nExecuting test via: {$command}\n");
@@ -155,6 +155,10 @@ final class WrapperWorker
 
     public function reset(): void
     {
+        if ($this->currentlyExecuting !== null) {
+            $this->currentlyExecuting->deleteWrappedTestSuite();
+        }
+
         $this->currentlyExecuting = null;
     }
 

--- a/test/Unit/ResultTester.php
+++ b/test/Unit/ResultTester.php
@@ -50,10 +50,10 @@ abstract class ResultTester extends TestBase
     {
         $functions = [];
         for ($i = 0; $i < $methodCount; ++$i) {
-            $functions[] = new TestMethod((string) $i, [], false, true, TMP_DIR);
+            $functions[] = new TestMethod((string) $i, '', [], false, true, TMP_DIR);
         }
 
-        $suite = new Suite('', $functions, false, true, TMP_DIR);
+        $suite = new Suite('', '', $functions, false, true, TMP_DIR);
         file_put_contents($suite->getTempFile(), (string) file_get_contents(FIXTURES . DS . 'results' . DS . $result));
         file_put_contents($suite->getTeamcityTempFile(), 'no data');
 

--- a/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
@@ -21,7 +21,7 @@ final class ExecutableTestTest extends TestBase
 
     public function setUpTest(): void
     {
-        $this->executableTestChild = new ExecutableTestChild('pathToFile', true, true, TMP_DIR);
+        $this->executableTestChild = new ExecutableTestChild('pathToFile', '', true, true, TMP_DIR);
     }
 
     public function testConstructor(): void

--- a/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -58,7 +58,7 @@ final class ResultPrinterTest extends ResultTester
 
     public function testAddTestShouldAddTest(): void
     {
-        $suite = new Suite('/path/to/ResultSuite.php', [], false, false, TMP_DIR);
+        $suite = new Suite('/path/to/ResultSuite.php', '', [], false, false, TMP_DIR);
 
         $this->printer->addTest($suite);
 
@@ -80,10 +80,10 @@ final class ResultPrinterTest extends ResultTester
     {
         $funcs = [];
         for ($i = 0; $i < 120; ++$i) {
-            $funcs[] = new TestMethod((string) $i, [], false, false, TMP_DIR);
+            $funcs[] = new TestMethod((string) $i, '', [], false, false, TMP_DIR);
         }
 
-        $suite = new Suite('/path', $funcs, false, false, TMP_DIR);
+        $suite = new Suite('/path', '', $funcs, false, false, TMP_DIR);
         $this->printer->addTest($suite);
         $this->getStartOutput();
         $numTestsWidth = $this->getObjectValue($this->printer, 'numTestsWidth');
@@ -176,9 +176,9 @@ final class ResultPrinterTest extends ResultTester
 
     public function testAddSuiteAddsFunctionCountToTotalTestCases(): void
     {
-        $suite = new Suite('/path', [
-            new TestMethod('funcOne', [], false, false, TMP_DIR),
-            new TestMethod('funcTwo', [], false, false, TMP_DIR),
+        $suite = new Suite('/path', '', [
+            new TestMethod('funcOne', '', [], false, false, TMP_DIR),
+            new TestMethod('funcTwo', '', [], false, false, TMP_DIR),
         ], false, false, TMP_DIR);
         $this->printer->addTest($suite);
         static::assertSame(2, $this->printer->getTotalCases());
@@ -186,7 +186,7 @@ final class ResultPrinterTest extends ResultTester
 
     public function testAddTestMethodIncrementsCountByOne(): void
     {
-        $method = new TestMethod('/path', ['testThisMethod'], false, false, TMP_DIR);
+        $method = new TestMethod('/path', '', ['testThisMethod'], false, false, TMP_DIR);
         $this->printer->addTest($method);
         static::assertSame(1, $this->printer->getTotalCases());
     }
@@ -514,7 +514,7 @@ final class ResultPrinterTest extends ResultTester
 
     public function testEmptyLogFileRaiseExceptionWithLastCommand(): void
     {
-        $test = new ExecutableTestChild(uniqid(), false, false, TMP_DIR);
+        $test = new ExecutableTestChild(uniqid(), '', false, false, TMP_DIR);
         $test->setLastCommand(uniqid());
 
         $this->expectException(RuntimeException::class);

--- a/test/Unit/Runners/PHPUnit/RunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/RunnerTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace ParaTest\Tests\Unit\Runners\PHPUnit;
 
+use function array_map;
+use function array_slice;
+use function explode;
+use function implode;
+
 /**
  * @internal
  *
@@ -14,6 +19,17 @@ namespace ParaTest\Tests\Unit\Runners\PHPUnit;
  */
 final class RunnerTest extends RunnerTestCase
 {
+    /**
+     * @param array<class-string> $classes
+     */
+    protected function expectExceptionMessageContainsClasses(array $classes): void
+    {
+        $classes = array_map(static function (string $class): string {
+            return implode('', array_slice(explode('\\', $class), -1));
+        }, $classes);
+        $this->expectExceptionMessageMatches('/' . implode('|', $classes) . '/');
+    }
+
     public function testFunctionalMode(): void
     {
         $this->bareOptions['--path']           = $this->fixture('dataprovider_tests' . DS . 'DataProviderTest.php');

--- a/test/Unit/Runners/PHPUnit/SuiteTest.php
+++ b/test/Unit/Runners/PHPUnit/SuiteTest.php
@@ -20,10 +20,10 @@ final class SuiteTest extends TestBase
     public function testConstructor(): void
     {
         $file        = uniqid('pathToFile_');
-        $testMethod1 = new TestMethod($file, [], false, false, TMP_DIR);
-        $testMethod2 = new TestMethod($file, [], false, false, TMP_DIR);
+        $testMethod1 = new TestMethod($file, '', [], false, false, TMP_DIR);
+        $testMethod2 = new TestMethod($file, '', [], false, false, TMP_DIR);
         $testMethods = [$testMethod1, $testMethod2];
-        $suite       = new Suite($file, $testMethods, false, false, TMP_DIR);
+        $suite       = new Suite($file, '', $testMethods, false, false, TMP_DIR);
 
         $commandArguments = $suite->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/TestMethodTest.php
+++ b/test/Unit/Runners/PHPUnit/TestMethodTest.php
@@ -19,7 +19,7 @@ final class TestMethodTest extends TestBase
     public function testConstructor(): void
     {
         $file       = uniqid('pathToFile_');
-        $testMethod = new TestMethod($file, ['method1', 'method2'], false, false, TMP_DIR);
+        $testMethod = new TestMethod($file, '', ['method1', 'method2'], false, false, TMP_DIR);
 
         $commandArguments = $testMethod->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
@@ -7,6 +7,10 @@ namespace ParaTest\Tests\Unit\Runners\PHPUnit;
 use InvalidArgumentException;
 use ParaTest\Runners\PHPUnit\WrapperRunner;
 
+use function array_map;
+use function implode;
+use function sha1;
+
 /**
  * @internal
  *
@@ -19,6 +23,21 @@ final class WrapperRunnerTest extends RunnerTestCase
 {
     /** {@inheritdoc } */
     protected $runnerClass = WrapperRunner::class;
+
+    /**
+     * Wrapper runner will use a TestSuite wrapper class based on the sha1 hash
+     * of the class name.
+     *
+     * @param array<class-string> $classes
+     */
+    protected function expectExceptionMessageContainsClasses(array $classes): void
+    {
+        $classes = array_map(static function (string $class): string {
+            return 'TestSuite' . sha1($class);
+        }, $classes);
+
+        $this->expectExceptionMessageMatches('/' . implode('|', $classes) . '/');
+    }
 
     public function testWrapperRunnerNotAvailableInFunctionalMode(): void
     {


### PR DESCRIPTION
PHPUnit's TestSuiteLoader will expect to be loading the
test class for the very first time, as Paratest uses
runs multiple phpunit commands within the same php
process, classes may already be loaded.

This happens with tests that reference other test classes
i.e. constants, static methods, inheritance etc.
causing paratest to crash :(

By dynamically generating a testsuite class for each
class we want to execute, we can avoid these problems
giving PHPunit a unique class to load each time.