### PR TITLE
Add support to write coverage text to file

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -100,7 +100,7 @@ parameters:
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#10 \\$coverageText of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects bool, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#10 \\$coverageText of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -100,11 +100,6 @@ parameters:
 			path: src/Runners/PHPUnit/Options.php
 
 		-
-			message: "#^Parameter \\#10 \\$coverageText of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Runners/PHPUnit/Options.php
-
-		-
 			message: "#^Parameter \\#11 \\$coverageXml of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -100,6 +100,11 @@ parameters:
 			path: src/Runners/PHPUnit/Options.php
 
 		-
+			message: "#^Parameter \\#10 \\$coverageText of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string|null, array\\<string\\>\\|int\\|string\\|true\\|null given\\.$#"
+			count: 1
+			path: src/Runners/PHPUnit/Options.php
+
+		-
 			message: "#^Parameter \\#11 \\$coverageXml of class ParaTest\\\\Runners\\\\PHPUnit\\\\Options constructor expects string\\|null, array\\<string\\>\\|bool\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Runners/PHPUnit/Options.php

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -203,9 +203,13 @@ abstract class BaseRunner implements RunnerInterface
         if (($coverageHtml = $this->options->coverageHtml()) !== null) {
             $reporter->html($coverageHtml);
         }
-
-        if ($this->options->coverageText()) {
-            $this->output->write($reporter->text());
+        
+        if (($coverageText = $this->options->coverageText()) !== null) {
+            if ($coverageText === '') {
+                $this->output->write($reporter->text());
+            } else {
+                file_put_contents($coverageText, $reporter->text());
+            }
         }
 
         if (($coverageXml = $this->options->coverageXml()) !== null) {

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -16,6 +16,7 @@ use function assert;
 use function mt_srand;
 use function shuffle;
 use function sprintf;
+use function file_put_contents;
 
 /**
  * @internal
@@ -203,7 +204,7 @@ abstract class BaseRunner implements RunnerInterface
         if (($coverageHtml = $this->options->coverageHtml()) !== null) {
             $reporter->html($coverageHtml);
         }
-        
+
         if (($coverageText = $this->options->coverageText()) !== null) {
             if ($coverageText === '') {
                 $this->output->write($reporter->text());

--- a/src/Runners/PHPUnit/BaseRunner.php
+++ b/src/Runners/PHPUnit/BaseRunner.php
@@ -13,10 +13,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_reverse;
 use function assert;
+use function file_put_contents;
 use function mt_srand;
 use function shuffle;
 use function sprintf;
-use function file_put_contents;
 
 /**
  * @internal

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -199,7 +199,7 @@ final class Options
     private $coverageHtml;
     /** @var string|null */
     private $coveragePhp;
-    /** @var bool */
+    /** @var string|null */
     private $coverageText;
     /** @var string|null */
     private $coverageXml;
@@ -240,7 +240,7 @@ final class Options
         ?string $coverageHtml,
         ?string $coveragePhp,
         int $coverageTestLimit,
-        bool $coverageText,
+        ?string $coverageText,
         ?string $coverageXml,
         string $cwd,
         array $excludeGroup,
@@ -321,7 +321,7 @@ final class Options
         assert($options['coverage-crap4j'] === null || is_string($options['coverage-crap4j']));
         assert($options['coverage-html'] === null || is_string($options['coverage-html']));
         assert($options['coverage-php'] === null || is_string($options['coverage-php']));
-        assert(is_bool($options['coverage-text']));
+        assert($options['coverage-text'] === false || $options['coverage-text'] === null || is_string($options['coverage-text']));
         assert($options['coverage-xml'] === null || is_string($options['coverage-xml']));
         assert($options['filter'] === null || is_string($options['filter']));
         assert(is_bool($options['functional']));
@@ -526,7 +526,7 @@ final class Options
             $options['coverage-html'],
             $options['coverage-php'],
             (int) $options['coverage-test-limit'],
-            $options['coverage-text'],
+            $options['coverage-text'] === false ? null : $options['coverage-text'] ?? '',
             $options['coverage-xml'],
             $cwd,
             $excludeGroup,
@@ -567,7 +567,7 @@ final class Options
             || $this->coverageCobertura !== null
             || $this->coverageCrap4j !== null
             || $this->coverageHtml !== null
-            || $this->coverageText
+            || $this->coverageText !== null
             || $this->coveragePhp !== null
             || $this->coverageXml !== null;
     }
@@ -641,8 +641,9 @@ final class Options
             new InputOption(
                 'coverage-text',
                 null,
-                InputOption::VALUE_NONE,
-                'Generate code coverage report in text format.'
+                InputOption::VALUE_OPTIONAL,
+                'Generate code coverage report in text format.',
+                false
             ),
             new InputOption(
                 'coverage-xml',
@@ -1058,7 +1059,7 @@ final class Options
         return $this->coveragePhp;
     }
 
-    public function coverageText(): bool
+    public function coverageText(): ?string
     {
         return $this->coverageText;
     }

--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -456,6 +456,10 @@ final class Options
 
             $codeCoverage = $configuration->codeCoverage();
 
+            if ($options['coverage-text'] === false && $codeCoverage->hasText()) {
+                $options['coverage-text'] = $codeCoverage->text()->target()->path();
+            }
+
             if ($options['coverage-clover'] === null && $codeCoverage->hasClover()) {
                 $options['coverage-clover'] = $codeCoverage->clover()->target()->path();
             }

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -25,7 +25,7 @@ abstract class TestBase extends PHPUnit\Framework\TestCase
 {
     /** @var class-string<RunnerInterface> */
     protected $runnerClass = Runner::class;
-    /** @var array<string, string|bool|int> */
+    /** @var array<string, string|bool|int|null> */
     protected $bareOptions = [];
 
     final protected function setUp(): void
@@ -43,7 +43,7 @@ abstract class TestBase extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param array<string, string|bool|int> $argv
+     * @param array<string, string|bool|int|null> $argv
      */
     final protected function createOptionsFromArgv(array $argv, ?string $cwd = null): Options
     {

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -65,7 +65,6 @@ final class BaseRunnerTest extends TestBase
         static::assertFileExists((string) $this->bareOptions['--coverage-crap4j']);
         static::assertFileExists((string) $this->bareOptions['--coverage-html']);
         static::assertFileExists((string) $this->bareOptions['--coverage-php']);
-        static::assertFileExists((string) $this->bareOptions['--coverage-text']);
         static::assertFileExists((string) $this->bareOptions['--coverage-xml']);
 
         static::assertStringContainsString('Code Coverage Report:', $runnerResult->getOutput());

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -29,7 +29,7 @@ final class BaseRunnerTest extends TestBase
             '--coverage-crap4j' => TMP_DIR . DS . 'coverage.crap4j',
             '--coverage-html' => TMP_DIR . DS . 'coverage.html',
             '--coverage-php' => TMP_DIR . DS . 'coverage.php',
-            '--coverage-text' => TMP_DIR . DS . 'coverage.txt',
+            '--coverage-text' => null,
             '--coverage-xml' => TMP_DIR . DS . 'coverage.xml',
             '--bootstrap' => BOOTSTRAP,
             '--whitelist' => $this->fixture('failing_tests'),

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -29,7 +29,7 @@ final class BaseRunnerTest extends TestBase
             '--coverage-crap4j' => TMP_DIR . DS . 'coverage.crap4j',
             '--coverage-html' => TMP_DIR . DS . 'coverage.html',
             '--coverage-php' => TMP_DIR . DS . 'coverage.php',
-            '--coverage-text' => true,
+            '--coverage-text' => TMP_DIR . DS . 'coverage.txt',
             '--coverage-xml' => TMP_DIR . DS . 'coverage.xml',
             '--bootstrap' => BOOTSTRAP,
             '--whitelist' => $this->fixture('failing_tests'),
@@ -54,6 +54,7 @@ final class BaseRunnerTest extends TestBase
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-crap4j']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-html']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-php']);
+        static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-text']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-xml']);
 
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-fully-configured.xml');
@@ -64,6 +65,7 @@ final class BaseRunnerTest extends TestBase
         static::assertFileExists((string) $this->bareOptions['--coverage-crap4j']);
         static::assertFileExists((string) $this->bareOptions['--coverage-html']);
         static::assertFileExists((string) $this->bareOptions['--coverage-php']);
+        static::assertFileExists((string) $this->bareOptions['--coverage-text']);
         static::assertFileExists((string) $this->bareOptions['--coverage-xml']);
 
         static::assertStringContainsString('Code Coverage Report:', $runnerResult->getOutput());

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -54,7 +54,6 @@ final class BaseRunnerTest extends TestBase
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-crap4j']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-html']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-php']);
-        static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-text']);
         static::assertFileDoesNotExist((string) $this->bareOptions['--coverage-xml']);
 
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-fully-configured.xml');
@@ -68,6 +67,25 @@ final class BaseRunnerTest extends TestBase
         static::assertFileExists((string) $this->bareOptions['--coverage-xml']);
 
         static::assertStringContainsString('Code Coverage Report:', $runnerResult->getOutput());
+        static::assertStringContainsString('Generating code coverage', $runnerResult->getOutput());
+    }
+
+    public function testGeneateTextCoverageToFile(): void
+    {
+        $file              = TMP_DIR . DS . 'coverage.txt';
+        $this->bareOptions = [
+            '--path' => $this->fixture('failing_tests'),
+            '--coverage-text' => $file,
+            '--bootstrap' => BOOTSTRAP,
+            '--whitelist' => $this->fixture('failing_tests'),
+        ];
+
+        static::assertFileDoesNotExist((string) $file);
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-fully-configured.xml');
+        $runnerResult                         = $this->runRunner();
+
+        static::assertFileExists((string) $file);
+        static::assertStringNotContainsString('Code Coverage Report:', $runnerResult->getOutput());
         static::assertStringContainsString('Generating code coverage', $runnerResult->getOutput());
     }
 

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -80,11 +80,11 @@ final class BaseRunnerTest extends TestBase
             '--whitelist' => $this->fixture('failing_tests'),
         ];
 
-        static::assertFileDoesNotExist((string) $file);
+        static::assertFileDoesNotExist($file);
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-fully-configured.xml');
         $runnerResult                         = $this->runRunner();
 
-        static::assertFileExists((string) $file);
+        static::assertFileExists($file);
         static::assertStringNotContainsString('Code Coverage Report:', $runnerResult->getOutput());
         static::assertStringContainsString('Generating code coverage', $runnerResult->getOutput());
     }

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -389,6 +389,8 @@ final class OptionsTest extends TestBase
         static::assertStringContainsString('coverage.php', $options->coveragePhp());
         static::assertNotNull($options->coverageXml());
         static::assertStringContainsString('xml-coverage', $options->coverageXml());
+        static::assertNotNull($options->coverageText());
+        static::assertStringContainsString('coverage.txt', $options->coverageText());
         static::assertNotNull($options->logJunit());
         static::assertStringContainsString('junit.xml', $options->logJunit());
 

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -237,7 +237,7 @@ final class OptionsTest extends TestBase
         static::assertNull($options->coverageHtml());
         static::assertNull($options->coveragePhp());
         static::assertSame(0, $options->coverageTestLimit());
-        static::assertFalse($options->coverageText());
+        static::assertNull($options->coverageText());
         static::assertNull($options->coverageXml());
         static::assertSame(__DIR__, $options->cwd());
         static::assertEmpty($options->excludeGroup());
@@ -318,7 +318,7 @@ final class OptionsTest extends TestBase
         static::assertSame('COVERAGE-HTML', $options->coverageHtml());
         static::assertSame('COVERAGE-PHP', $options->coveragePhp());
         static::assertSame(3, $options->coverageTestLimit());
-        static::assertTrue($options->coverageText());
+        static::assertSame('', $options->coverageText());
         static::assertSame('COVERAGE-XML', $options->coverageXml());
         static::assertSame(__DIR__, $options->cwd());
         static::assertSame(['EXCLUDE-GROUP'], $options->excludeGroup());

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -281,7 +281,7 @@ final class OptionsTest extends TestBase
             '--coverage-html' => 'COVERAGE-HTML',
             '--coverage-php' => 'COVERAGE-PHP',
             '--coverage-test-limit' => 3,
-            '--coverage-text' => true,
+            '--coverage-text' => null,
             '--coverage-xml' => 'COVERAGE-XML',
             '--exclude-group' => 'EXCLUDE-GROUP',
             '--filter' => 'FILTER',

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -403,7 +403,7 @@ final class OptionsTest extends TestBase
             '--coverage-crap4j' => 'COVERAGE-CRAP4J',
             '--coverage-html' => 'COVERAGE-HTML',
             '--coverage-php' => 'COVERAGE-PHP',
-            '--coverage-text' => true,
+            '--coverage-text' => false,
             '--coverage-xml' => 'COVERAGE-XML',
             '--no-coverage' => true,
         ];


### PR DESCRIPTION
Just like for PHPUnit, you may want to store the "coverage text" to a file. 

