### PR TITLE
Ungrouped tests should have `default` group assigned

### DIFF
--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -37,6 +37,7 @@ use function is_int;
 use function ksort;
 use function preg_match;
 use function sprintf;
+use function strpos;
 use function strrpos;
 use function substr;
 use function trim;
@@ -319,7 +320,12 @@ final class SuiteLoader
     {
         $result = [];
 
+        /** @var string[] $groups */
         $groups = Test::getGroups($class->getName(), $method->getName());
+        if ($this->containsOnlyVirtualGroups($groups)) {
+            $groups[] = 'default';
+        }
+
         if (! $this->testMatchGroupOptions($groups)) {
             return $result;
         }
@@ -501,5 +507,21 @@ final class SuiteLoader
         );
 
         $this->output->writeln('done [' . $timer->stop()->asString() . ']');
+    }
+
+    /**
+     * @see PHPUnit\Framework\TestCase::containsOnlyVirtualGroups
+     *
+     * @param string[] $groups
+     */
+    private function containsOnlyVirtualGroups(array $groups): bool
+    {
+        foreach ($groups as $group) {
+            if (strpos($group, '__phpunit_') !== 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/test/Unit/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/Unit/Runners/PHPUnit/SuiteLoaderTest.php
@@ -378,6 +378,14 @@ final class SuiteLoaderTest extends TestBase
         static::assertCount(3, $loader->getTestMethods());
     }
 
+    public function testUngroupedTestShouldHaveDefaultGroupAssigned(): void
+    {
+        $this->bareOptions['--path']  = $this->fixture('group_default');
+        $this->bareOptions['--group'] = 'default';
+        $loader                       = $this->loadSuite();
+        static::assertCount(2, $loader->getTestMethods());
+    }
+
     /**
      * @return string[]
      */

--- a/test/fixtures/group_default/GroupDefaultTest.php
+++ b/test/fixtures/group_default/GroupDefaultTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\passing_tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class GroupDefaultTest extends TestCase
+{
+    public function testTruth(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @covers ParaTest\Tests\fixtures\passing_tests\GroupDefaultTest
+     */
+    public function testTruthWithCovers(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @group group1
+     */
+    public function testFalsehood(): void
+    {
+        $this->assertFalse(false);
+    }
+}

--- a/test/fixtures/group_default/GroupNonDefaultTest.php
+++ b/test/fixtures/group_default/GroupNonDefaultTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\passing_tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group group1
+ */
+final class GroupNonDefaultTest extends TestCase
+{
+    public function testTruth(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/paratestphp/paratest/issues/622
