### PR TITLE
Respect configuration options of text coverage

### DIFF
--- a/src/Coverage/CoverageReporter.php
+++ b/src/Coverage/CoverageReporter.php
@@ -99,9 +99,10 @@ final class CoverageReporter
     {
         $text = new Text();
         if ($this->codeCoverageConfiguration !== null && $this->codeCoverageConfiguration->hasText()) {
-            $text = new Text(
-                50,
-                90,
+            $hasHtml = $this->codeCoverageConfiguration->hasHtml();
+            $text    = new Text(
+                $hasHtml ? $this->codeCoverageConfiguration->html()->lowUpperBound() : 50,
+                $hasHtml ? $this->codeCoverageConfiguration->html()->highLowerBound() : 90,
                 $this->codeCoverageConfiguration->text()->showUncoveredFiles(),
                 $this->codeCoverageConfiguration->text()->showOnlySummary()
             );

--- a/src/Coverage/CoverageReporter.php
+++ b/src/Coverage/CoverageReporter.php
@@ -98,6 +98,14 @@ final class CoverageReporter
     public function text(): string
     {
         $text = new Text();
+        if ($this->codeCoverageConfiguration !== null && $this->codeCoverageConfiguration->hasText()) {
+            $text = new Text(
+                50,
+                90,
+                $this->codeCoverageConfiguration->text()->showUncoveredFiles(),
+                $this->codeCoverageConfiguration->text()->showOnlySummary()
+            );
+        }
 
         return $text->process($this->coverage);
     }

--- a/test/Unit/Coverage/CoverageReporterTest.php
+++ b/test/Unit/Coverage/CoverageReporterTest.php
@@ -29,6 +29,11 @@ final class CoverageReporterTest extends TestBase
     {
         static::skipIfCodeCoverageNotEnabled();
 
+        $this->createCoverageReporter('phpunit-fully-configured.xml');
+    }
+
+    private function createCoverageReporter(string $fixtureFile): void
+    {
         $filter = new Filter();
         $filter->includeFile(__FILE__);
         $codeCoverage = new CodeCoverage((new Selector())->forLineCoverage($filter), $filter);
@@ -36,7 +41,7 @@ final class CoverageReporterTest extends TestBase
             __FILE__ => [__LINE__ => 1],
         ]), uniqid());
 
-        $configuration = (new Loader())->load($this->fixture('phpunit-fully-configured.xml'));
+        $configuration = (new Loader())->load($this->fixture($fixtureFile));
 
         $this->coverageReporter = new CoverageReporter($codeCoverage, $configuration->codeCoverage());
     }
@@ -99,11 +104,32 @@ final class CoverageReporterTest extends TestBase
         static::assertFileExists($target);
     }
 
-    public function testGenerateText(): void
+    /**
+     * @dataProvider generateTextProvider
+     */
+    public function testGenerateText(string $fixtureFile, string $expectedContainedString): void
     {
+        $this->createCoverageReporter($fixtureFile);
         $output = $this->coverageReporter->text();
 
-        static::assertStringContainsString('Code Coverage Report:', $output);
+        static::assertStringContainsString($expectedContainedString, $output);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function generateTextProvider(): array
+    {
+        return [
+            'showOnlySummary = false' => [
+                'fixtureFile' => 'phpunit-fully-configured.xml',
+                'expectedContainedString' => 'Code Coverage Report:',
+            ],
+            'showOnlySummary = true' => [
+                'fixtureFile' => 'phpunit-coverage-text-show-only-summary.xml',
+                'expectedContainedString' => 'Code Coverage Report Summary:',
+            ],
+        ];
     }
 
     public function testGenerateXml(): void

--- a/test/fixtures/phpunit-coverage-text-show-only-summary.xml
+++ b/test/fixtures/phpunit-coverage-text-show-only-summary.xml
@@ -31,7 +31,7 @@
             <crap4j outputFile="../tmp/crap4j.xml" threshold="50"/>
             <html outputDirectory="../tmp/html-coverage" lowUpperBound="50" highLowerBound="90"/>
             <php outputFile="../tmp/coverage.php"/>
-            <text outputFile="../tmp/coverage.txt" showUncoveredFiles="false" showOnlySummary="false"/>
+            <text outputFile="../tmp/coverage.txt" showUncoveredFiles="false" showOnlySummary="true"/>
             <xml outputDirectory="../tmp/xml-coverage"/>
         </report>
     </coverage>


### PR DESCRIPTION
This resolves #385

`showOnlySummary` was changed to `false` in `test/fixtures/phpunit-fully-configured.xml`, as the other tests rely on the whole text coverage report being created.

I created `test/fixtures/phpunit-coverage-text-show-only-summary.xml`, which only differs from `test/fixtures/phpunit-fully-configured.xml` in part of the option `showOnlySummary` being set to `true`.

For being able to use the dataProvider `generateTextProvider` it was neccessary to overwrite the default configuration in `test/Unit/Coverage/CoverageReporterTest.php`. Therefore I extracted a method `createCoverageReporter` which takes a fixture path as an argument (to reduce code redundancy). This function is called in `setup`, as well as in the test method `testGenerateText`.

With `showOnlySummary` set to false, the text coverage report looks like this:
```
Code Coverage Report:   
  2021-08-17 07:45:37   
                        
 Summary:               
  Classes: 100.00% (1/1)
  Methods: 100.00% (1/1)
  Lines:   100.00% (1/1)

ParaTest\Tests\Unit\Coverage\CoverageReporterTest
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  1/  1)
```

With `showOnlySummary` set to true, the text coverage report looks like this:
```
Code Coverage Report Summary:
  Classes: 100.00% (1/1)     
  Methods: 100.00% (1/1)     
  Lines:   100.00% (1/1)
```
So the test checks, if the report contains `Code Coverage Report:`, when `showOnlySummary` is false and `Code Coverage Report Summary:`, when `showOnlySummary` is true.

In lines 103 and 104, the parameters `lowUpperBound` and `highLowerBound` are hard coded to the default parameter values. PHPUnit does not seem to make these parameters configurable for text coverage.