### PR TITLE
Escape Symfony Console output

### DIFF
--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -9,6 +9,7 @@ use ParaTest\Logging\JUnit\Reader;
 use ParaTest\Logging\LogInterpreter;
 use PHPUnit\Util\Color;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_filter;
@@ -200,10 +201,13 @@ final class ResultPrinter
             $toFilter[] = $this->getSkipped();
         }
 
-        $failures = array_filter($toFilter);
+        $failures        = array_filter($toFilter);
+        $escapedFailures = array_map(static function (string $failure): string {
+            return OutputFormatter::escape($failure);
+        }, $failures);
 
         $this->output->write($this->getHeader());
-        $this->output->write(implode("---\n\n", $failures));
+        $this->output->write(implode("---\n\n", $escapedFailures));
         $this->output->write($this->getFooter());
 
         if ($this->teamcityLogFileHandle === null) {

--- a/test/Unit/ResultTester.php
+++ b/test/Unit/ResultTester.php
@@ -16,6 +16,8 @@ abstract class ResultTester extends TestBase
     /** @var Suite */
     protected $failureSuite;
     /** @var Suite */
+    protected $otherFailureSuite;
+    /** @var Suite */
     protected $otherErrorSuite;
     /** @var Suite */
     protected $mixedSuite;
@@ -36,6 +38,7 @@ abstract class ResultTester extends TestBase
         $this->warningSuite      = $this->getSuiteWithResult('single-warning.xml', 1);
         $this->otherErrorSuite   = $this->getSuiteWithResult('single-werror2.xml', 1);
         $this->failureSuite      = $this->getSuiteWithResult('single-wfailure.xml', 3);
+        $this->otherFailureSuite = $this->getSuiteWithResult('single-wfailure2.xml', 3);
         $this->mixedSuite        = $this->getSuiteWithResult('mixed-results.xml', 7);
         $this->skipped           = $this->getSuiteWithResult('single-skipped.xml', 1);
         $this->passingSuite      = $this->getSuiteWithResult('single-passing.xml', 3);

--- a/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/BaseRunnerTest.php
@@ -147,9 +147,9 @@ final class BaseRunnerTest extends TestBase
 
         // these numbers represent the tests in fixtures/failing_tests
         // so will need to be updated when tests are added or removed
-        static::assertCount(6, $suites);
-        static::assertCount(24, $cases);
-        static::assertCount(6, $failures);
+        static::assertCount(7, $suites);
+        static::assertCount(25, $cases);
+        static::assertCount(7, $failures);
         static::assertCount(2, $warnings);
         static::assertCount(4, $skipped);
         static::assertCount(3, $errors);

--- a/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -466,6 +466,22 @@ final class ResultPrinterTest extends ResultTester
         static::assertStringNotContainsString('UnitTestWithMethodAnnotationsTest', $output);
     }
 
+    public function testColorsParsing(): void
+    {
+        $this->options = $this->createOptionsFromArgv(['--colors' => true, '--verbose' => true]);
+        $this->printer = new ResultPrinter($this->interpreter, $this->output, $this->options);
+        $this->printer->addTest($this->otherFailureSuite);
+
+        $this->printer->start();
+        $this->printer->printFeedback($this->otherFailureSuite);
+        $this->printer->printResults();
+
+        $output = $this->output->fetch();
+        static::assertStringContainsString('FAILURES', $output);
+        static::assertStringContainsString('FailingSymfonyOutputCollisionTest', $output);
+        static::assertStringContainsString('<bg=%s>', $output);
+    }
+
     public function testSkippedOutpusMessagesWithVerbose(): void
     {
         $this->options = $this->createOptionsFromArgv(['--colors' => true, '--verbose' => 1]);

--- a/test/Unit/Runners/PHPUnit/SuiteLoaderTest.php
+++ b/test/Unit/Runners/PHPUnit/SuiteLoaderTest.php
@@ -376,7 +376,7 @@ final class SuiteLoaderTest extends TestBase
         $this->bareOptions['--path'] = $this->fixture('failing_tests');
         $loader                      = $this->loadSuite();
 
-        static::assertCount(24, $loader->getTestMethods());
+        static::assertCount(25, $loader->getTestMethods());
     }
 
     public function testTestMethodsFromErroringDataProviderReturnTheSimpleMethodToBeRunInTheSubprocess(): void

--- a/test/fixtures/failing_tests/FailingSymfonyOutputCollisionTest.php
+++ b/test/fixtures/failing_tests/FailingSymfonyOutputCollisionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\failing_tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class FailingSymfonyOutputCollisionTest extends TestCase
+{
+    public function testInvalidLogic(): void
+    {
+        $this->assertSame('<bg=%s> </>', '');
+    }
+}

--- a/test/fixtures/results/single-wfailure2.xml
+++ b/test/fixtures/results/single-wfailure2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/UnitTestWithMethodAnnotationsTest.php" tests="3" assertions="3" failures="1" errors="0" time="0.005895">
+    <testcase name="testInvalidLogic" class="UnitTestWithMethodAnnotationsTest" file="/home/brian/Projects/parallel-phpunit/test/fixtures/tests/FailingSymfonyOutputCollisionTest.php" line="18" assertions="1" time="0.001632">
+      <failure type="PHPUnit\Framework\ExpectationFailedException">FailingSymfonyOutputCollisionTest::testInvalidLogic
+        Failed asserting that two strings are identical.
+        --- Expected
+        +++ Actual
+        @@ @@
+        -'&lt;bg=%s&gt; &lt;/&gt;'
+        +''
+
+        /home/brian/Projects/parallel-phpunit/test/fixtures/tests/FailingSymfonyOutputCollisionTest.php:18
+      </failure>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
When output contained `<bg=%s>` Symfony Console tried to interpret `%s` color, it needs to be escaped.