### PR TITLE
Fix detection of logical CPU cores on windows

### DIFF
--- a/src/Runners/PHPUnit/Options.php
+++ b/src/Runners/PHPUnit/Options.php
@@ -883,7 +883,7 @@ final class Options
         // @codeCoverageIgnoreStart
         } elseif (DIRECTORY_SEPARATOR === '\\') {
             // Windows
-            if (($process = @popen('wmic cpu get NumberOfCores', 'rb')) !== false) {
+            if (($process = @popen('wmic cpu get NumberOfLogicalProcessors', 'rb')) !== false) {
                 fgets($process);
                 $cores = (int) fgets($process);
                 pclose($process);


### PR DESCRIPTION
before this change only physical cpus were detected on windows.
initially reported in https://github.com/phpstan/phpstan-src/pull/1115#issuecomment-1079862741

fix inspired by similar code in phpstan-src:
https://github.com/phpstan/phpstan-src/blob/a95ce30d8d036fe5232815ff12d229cea4b1f46a/src/Process/CpuCoreCounter.php#L41-L50

I ran a few benchmarks, and interesstingly the overall duration when running the phpstan test-suite before/after this PR did nearly not change. 
nevertheless I figured this fixed should be merged, as it adjusts the implementation to the actual expectations described in the method body.