### PR TITLE
Fix PHP 8.2 deprecation

### DIFF
--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -239,7 +239,7 @@ final class ResultPrinter
             $teamcityLogFile = $test->getTeamcityTempFile();
 
             if (filesize($teamcityLogFile) === 0) {
-                throw new EmptyLogFileException("Teamcity format file ${teamcityLogFile} is empty");
+                throw new EmptyLogFileException("Teamcity format file {$teamcityLogFile} is empty");
             }
 
             $result = file_get_contents($teamcityLogFile);


### PR DESCRIPTION
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /Users/shyim/Code/sw6/vendor/brianium/paratest/src/Runners/PHPUnit/ResultPrinter.php on line 238
