### PR TITLE
Add version information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
+        "jean85/pretty-package-versions": "^1.6 || ^2.0",
         "phpunit/php-code-coverage": "^9.2.15",
         "phpunit/php-file-iterator": "^3.0.6",
         "phpunit/php-timer": "^5.0.3",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "jean85/pretty-package-versions": "^1.6 || ^2.0",
+        "jean85/pretty-package-versions": "^2.0",
         "phpunit/php-code-coverage": "^9.2.15",
         "phpunit/php-file-iterator": "^3.0.6",
         "phpunit/php-timer": "^5.0.3",

--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -48,7 +48,8 @@ final class ParaTestCommand extends Command
         $application = new Application();
         $command     = new self($cwd, self::COMMAND_NAME);
 
-        $application->setVersion('Paratest ' . PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion());
+        $application->setName('Paratest');
+        $application->setVersion(PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion());
         $application->add($command);
         $application->setDefaultCommand((string) $command->getName(), true);
 

--- a/src/Console/Commands/ParaTestCommand.php
+++ b/src/Console/Commands/ParaTestCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ParaTest\Console\Commands;
 
 use InvalidArgumentException;
+use Jean85\PrettyVersions;
 use ParaTest\Runners\PHPUnit\Options;
 use ParaTest\Runners\PHPUnit\Runner;
 use ParaTest\Runners\PHPUnit\RunnerInterface;
@@ -47,6 +48,7 @@ final class ParaTestCommand extends Command
         $application = new Application();
         $command     = new self($cwd, self::COMMAND_NAME);
 
+        $application->setVersion('Paratest ' . PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion());
         $application->add($command);
         $application->setDefaultCommand((string) $command->getName(), true);
 

--- a/test/Unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/Unit/Console/Commands/ParaTestCommandTest.php
@@ -41,8 +41,8 @@ final class ParaTestCommandTest extends TestBase
         static::assertArrayHasKey(ParaTestCommand::COMMAND_NAME, $commands);
         static::assertInstanceOf(ParaTestCommand::class, $commands[ParaTestCommand::COMMAND_NAME]);
         static::assertSame(
-            'Paratest ' . PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion(),
-            $application->getVersion()
+            'Paratest <info>' . PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion() . '</info>',
+            $application->getLongVersion()
         );
     }
 

--- a/test/Unit/Console/Commands/ParaTestCommandTest.php
+++ b/test/Unit/Console/Commands/ParaTestCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ParaTest\Tests\Unit\Console\Commands;
 
 use InvalidArgumentException;
+use Jean85\PrettyVersions;
 use ParaTest\Console\Commands\ParaTestCommand;
 use ParaTest\Tests\TestBase;
 use ParaTest\Tests\Unit\Runners\PHPUnit\EmptyRunnerStub;
@@ -39,6 +40,10 @@ final class ParaTestCommandTest extends TestBase
 
         static::assertArrayHasKey(ParaTestCommand::COMMAND_NAME, $commands);
         static::assertInstanceOf(ParaTestCommand::class, $commands[ParaTestCommand::COMMAND_NAME]);
+        static::assertSame(
+            'Paratest ' . PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion(),
+            $application->getVersion()
+        );
     }
 
     public function testMessagePrintedWhenInvalidConfigFileSupplied(): void


### PR DESCRIPTION
Fixes #624.

This leverages my own package that isolate us from any transient dependency: https://github.com/jean85/pretty-package-versions#compatibility

The output with this PR is:
![immagine](https://user-images.githubusercontent.com/6729988/173858042-1cc4f3e5-b07d-4019-9a21-a2fa8218df09.png)

With a tagged version, the output would be:
```
$ vendor/bin/paratest --version                                                                 
Paratest 6.4.0
```