### PR TITLE
Fix stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5.0
+      - uses: actions/stale@v5.0
         with:
           days-before-stale: 60
           days-before-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
           days-before-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          debug-only: false # set to true for a dry-run
+          debug-only: true # set to true for a dry-run
 
           exempt-issue-labels: "Backlog,In Progress"
           stale-issue-label: "Stale"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5.0
+      - uses: actions/stale@v5
         with:
           days-before-stale: 60
           days-before-close: 14

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,8 @@ jobs:
           days-before-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          operations-per-run: 100
+          ascending: false
           debug-only: true # set to true for a dry-run
 
           exempt-issue-labels: "Backlog,In Progress"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
           days-before-pr-close: -1
           operations-per-run: 100
           ascending: false
-          debug-only: true # set to true for a dry-run
+          debug-only: false # set to true for a dry-run
 
           exempt-issue-labels: "Backlog,In Progress"
           stale-issue-label: "Stale"


### PR DESCRIPTION
#667 had some issues, and the first run crashed hard: https://github.com/paratestphp/paratest/runs/6910195975?check_suite_focus=true#step:1:35

So I decided to push this other branch and dry-run the action from here (silly me for not doing it before).

The first successful run showed that not enough issues were being tackled, and all were not stale: https://github.com/paratestphp/paratest/runs/6914074232?check_suite_focus=true#step:2:28

So I changed the action to tackle older first, and increased the limit of operation per run: https://github.com/paratestphp/paratest/runs/6914147328?check_suite_focus=true#step:2:1023