### PR TITLE
Add TestDox support, fix `--verbose` option type, add `--debug` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ csfix: vendor
 
 .PHONY: static-analysis
 static-analysis: vendor
-	vendor/bin/psalm $(PSALM_ARGS)
+	php -d zend.assertions=1 vendor/bin/psalm $(PSALM_ARGS)
 
 coverage/junit.xml: vendor $(SRCS) Makefile
 	php -d zend.assertions=1 vendor/bin/phpunit \
@@ -33,6 +33,12 @@ coverage/junit.xml: vendor $(SRCS) Makefile
 	php -d zend.assertions=1 bin/paratest \
 		--no-coverage \
 		--processes=1 \
+		--runner=Runner \
+		$(PARATEST_ARGS)
+	php -d zend.assertions=1 bin/paratest \
+		--no-coverage \
+		--processes=1 \
+		--runner=WrapperRunner \
 		$(PARATEST_ARGS)
 	php -d zend.assertions=1 \
 		-d pcov.enabled=1 \

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/php-timer": "^5.0.3",
         "phpunit/phpunit": "^9.5.21",
         "sebastian/environment": "^5.1.4",
-        "symfony/console": "^5.4.9 || ^6.1.1",
+        "symfony/console": "^5.4.9 || ^6.1.2",
         "symfony/process": "^5.4.8 || ^6.1.0"
     },
     "require-dev": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/Logging/JUnit/Reader.php">
-    <MixedArgument occurrences="4">
-      <code>$callback($case)</code>
+    <MixedArgument occurrences="3">
       <code>$singleTestCase</code>
       <code>$singleTestSuiteXml</code>
       <code>$singleTestSuiteXml</code>
@@ -13,11 +12,6 @@
       <code>$singleTestSuiteXml</code>
     </MixedAssignment>
   </file>
-  <file src="src/Logging/JUnit/TestCase.php">
-    <MixedArrayAssignment occurrences="1">
-      <code>$case-&gt;{$group}[]</code>
-    </MixedArrayAssignment>
-  </file>
   <file src="src/Parser/Parser.php">
     <DeprecatedClass occurrences="1">
       <code>new StandardTestSuiteLoader()</code>
@@ -27,6 +21,17 @@
       <code>self::$alreadyLoadedSources</code>
       <code>self::$alreadyLoadedSources[$srcPath]</code>
     </PropertyTypeCoercion>
+  </file>
+  <file src="src/Runners/PHPUnit/ResultPrinter.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>self::TESTDOX_SYMBOLS[get_class($case)]</code>
+    </InvalidArrayOffset>
+    <MixedArgument occurrences="1">
+      <code>self::TESTDOX_SYMBOLS[get_class($case)]</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>new $class($case-&gt;name)</code>
+    </MixedMethodCall>
   </file>
   <file src="src/Runners/PHPUnit/Runner.php">
     <MixedArgumentTypeCoercion occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/Logging/JUnit/Reader.php">
+    <ArgumentTypeCoercion occurrences="1"/>
     <MixedArgument occurrences="3">
       <code>$singleTestCase</code>
       <code>$singleTestSuiteXml</code>
@@ -11,6 +12,14 @@
       <code>$singleTestSuiteXml</code>
       <code>$singleTestSuiteXml</code>
     </MixedAssignment>
+  </file>
+  <file src="src/Logging/JUnit/TestCase.php">
+    <ImplicitToStringCast occurrences="4">
+      <code>$node['class']</code>
+      <code>$node['file']</code>
+      <code>$node['line']</code>
+      <code>$node['name']</code>
+    </ImplicitToStringCast>
   </file>
   <file src="src/Parser/Parser.php">
     <DeprecatedClass occurrences="1">

--- a/src/Logging/JUnit/ErrorTestCase.php
+++ b/src/Logging/JUnit/ErrorTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class ErrorTestCase extends TestCaseWithMessage
+{
+    public function getXmlTagName(): string
+    {
+        return 'error';
+    }
+}

--- a/src/Logging/JUnit/FailureTestCase.php
+++ b/src/Logging/JUnit/FailureTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class FailureTestCase extends TestCaseWithMessage
+{
+    public function getXmlTagName(): string
+    {
+        return 'failure';
+    }
+}

--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -213,10 +213,7 @@ final class Reader implements MetaProviderInterface
      */
     private function getMessagesOfType(TestSuite $testSuite, callable $callback): array
     {
-        $messages = array_filter($testSuite->cases, static function (TestCase $testCase): bool {
-            return $testCase instanceof TestCaseWithMessage;
-        });
-        $messages = array_filter($messages, $callback);
+        $messages = array_filter($testSuite->cases, $callback);
         $messages = array_map(static function (TestCaseWithMessage $testCase): string {
             return $testCase->text;
         }, $messages);

--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -8,16 +8,15 @@ use InvalidArgumentException;
 use ParaTest\Logging\MetaProviderInterface;
 use SimpleXMLElement;
 
-use function array_key_exists;
+use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_sum;
+use function array_values;
 use function assert;
-use function count;
 use function file_exists;
 use function file_get_contents;
 use function filesize;
-use function is_string;
 use function str_repeat;
 use function unlink;
 
@@ -72,7 +71,7 @@ final class Reader implements MetaProviderInterface
         }
 
         $risky  = array_sum(array_map(static function (TestCase $testCase): int {
-            return count($testCase->risky);
+            return (int) ($testCase instanceof RiskyTestCase);
         }, $cases));
         $risky += array_sum(array_map(static function (TestSuite $testSuite): int {
             return $testSuite->risky;
@@ -162,8 +161,8 @@ final class Reader implements MetaProviderInterface
      */
     public function getErrors(): array
     {
-        return $this->getMessagesOfType($this->suite, static function (TestCase $case): array {
-            return $case->errors;
+        return $this->getMessagesOfType($this->suite, static function (TestCase $case): bool {
+            return $case instanceof ErrorTestCase;
         });
     }
 
@@ -172,8 +171,8 @@ final class Reader implements MetaProviderInterface
      */
     public function getWarnings(): array
     {
-        return $this->getMessagesOfType($this->suite, static function (TestCase $case): array {
-            return $case->warnings;
+        return $this->getMessagesOfType($this->suite, static function (TestCase $case): bool {
+            return $case instanceof WarningTestCase;
         });
     }
 
@@ -182,8 +181,8 @@ final class Reader implements MetaProviderInterface
      */
     public function getFailures(): array
     {
-        return $this->getMessagesOfType($this->suite, static function (TestCase $case): array {
-            return $case->failures;
+        return $this->getMessagesOfType($this->suite, static function (TestCase $case): bool {
+            return $case instanceof FailureTestCase;
         });
     }
 
@@ -192,8 +191,8 @@ final class Reader implements MetaProviderInterface
      */
     public function getRisky(): array
     {
-        return $this->getMessagesOfType($this->suite, static function (TestCase $case): array {
-            return $case->risky;
+        return $this->getMessagesOfType($this->suite, static function (TestCase $case): bool {
+            return $case instanceof RiskyTestCase;
         });
     }
 
@@ -202,30 +201,30 @@ final class Reader implements MetaProviderInterface
      */
     public function getSkipped(): array
     {
-        return $this->getMessagesOfType($this->suite, static function (TestCase $case): array {
-            return $case->skipped;
+        return $this->getMessagesOfType($this->suite, static function (TestCase $case): bool {
+            return $case instanceof SkippedTestCase;
         });
     }
 
     /**
+     * @param callable(TestCase):bool $callback
+     *
      * @return string[]
      */
     private function getMessagesOfType(TestSuite $testSuite, callable $callback): array
     {
-        $messages = [];
+        $messages = array_filter($testSuite->cases, static function (TestCase $testCase): bool {
+            return $testCase instanceof TestCaseWithMessage;
+        });
+        $messages = array_filter($messages, $callback);
+        $messages = array_map(static function (TestCaseWithMessage $testCase): string {
+            return $testCase->text;
+        }, $messages);
+
         foreach ($testSuite->suites as $suite) {
             $messages = array_merge($messages, $this->getMessagesOfType($suite, $callback));
         }
 
-        foreach ($testSuite->cases as $case) {
-            $messages = array_merge($messages, array_map(static function (array $msg): string {
-                assert(array_key_exists('text', $msg));
-                assert(is_string($msg['text']));
-
-                return $msg['text'];
-            }, $callback($case)));
-        }
-
-        return $messages;
+        return array_values($messages);
     }
 }

--- a/src/Logging/JUnit/RiskyTestCase.php
+++ b/src/Logging/JUnit/RiskyTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class RiskyTestCase extends TestCaseWithMessage
+{
+    public function getXmlTagName(): string
+    {
+        return 'error';
+    }
+}

--- a/src/Logging/JUnit/SkippedTestCase.php
+++ b/src/Logging/JUnit/SkippedTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class SkippedTestCase extends TestCaseWithMessage
+{
+    public function getXmlTagName(): string
+    {
+        return 'skipped';
+    }
+}

--- a/src/Logging/JUnit/SuccessTestCase.php
+++ b/src/Logging/JUnit/SuccessTestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class SuccessTestCase extends TestCase
+{
+}

--- a/src/Logging/JUnit/TestCase.php
+++ b/src/Logging/JUnit/TestCase.php
@@ -165,10 +165,10 @@ abstract class TestCase
             if ((string) $node['class'] !== '') {
                 $text = sprintf(
                     "%s::%s\n\n%s:%s",
-                    (string) $node['class'],
-                    (string) $node['name'],
-                    (string) $node['file'],
-                    (string) $node['line']
+                    $node['class'],
+                    $node['name'],
+                    $node['file'],
+                    $node['line']
                 );
             }
 

--- a/src/Logging/JUnit/TestCaseWithMessage.php
+++ b/src/Logging/JUnit/TestCaseWithMessage.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ *
+ * @readonly
+ */
+abstract class TestCaseWithMessage extends TestCase
+{
+    /** @var string|null */
+    public $type;
+
+    /** @var string */
+    public $text;
+
+    /** @var string|null */
+    public $systemOutput;
+
+    public function __construct(
+        string $name,
+        string $class,
+        string $file,
+        int $line,
+        int $assertions,
+        float $time,
+        ?string $type,
+        string $text,
+        ?string $systemOutput
+    ) {
+        parent::__construct($name, $class, $file, $line, $assertions, $time);
+
+        $this->type         = $type;
+        $this->text         = $text;
+        $this->systemOutput = $systemOutput;
+    }
+
+    abstract public function getXmlTagName(): string;
+}

--- a/src/Logging/JUnit/WarningTestCase.php
+++ b/src/Logging/JUnit/WarningTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Logging\JUnit;
+
+/**
+ * @internal
+ */
+final class WarningTestCase extends TestCaseWithMessage
+{
+    public function getXmlTagName(): string
+    {
+        return 'warning';
+    }
+}

--- a/src/Logging/JUnit/Writer.php
+++ b/src/Logging/JUnit/Writer.php
@@ -135,31 +135,20 @@ final class Writer
         $caseNode->setAttribute('assertions', (string) $case->assertions);
         $caseNode->setAttribute('time', sprintf('%F', $case->time));
 
-        $this->appendDefects($caseNode, $case->failures, 'failure');
-        $this->appendDefects($caseNode, $case->errors, 'error');
-        $this->appendDefects($caseNode, $case->warnings, 'warning');
-        $this->appendDefects($caseNode, $case->risky, 'error');
-        $this->appendDefects($caseNode, $case->skipped, 'skipped');
-
-        return $caseNode;
-    }
-
-    /**
-     * Append error or failure nodes to the given testcase node.
-     *
-     * @param array<int, array{type: string, text: string}> $defects
-     */
-    private function appendDefects(DOMElement $caseNode, array $defects, string $type): void
-    {
-        foreach ($defects as $defect) {
-            if ($type === 'skipped') {
-                $defectNode = $this->document->createElement($type);
+        if ($case instanceof TestCaseWithMessage) {
+            if ($case instanceof SkippedTestCase) {
+                $defectNode = $this->document->createElement($case->getXmlTagName());
             } else {
-                $defectNode = $this->document->createElement($type, htmlspecialchars($defect['text'], ENT_XML1));
-                $defectNode->setAttribute('type', $defect['type']);
+                $defectNode = $this->document->createElement($case->getXmlTagName(), htmlspecialchars($case->text, ENT_XML1));
+                $type       = $case->type;
+                if ($type !== null) {
+                    $defectNode->setAttribute('type', $type);
+                }
             }
 
             $caseNode->appendChild($defectNode);
         }
+
+        return $caseNode;
     }
 }

--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -296,8 +296,8 @@ final class ResultPrinter
 
         $this->results->addReader($reader);
 
-        if ($teamcityContent !== null && $this->printsTeamcity) {
-            $this->output->write($teamcityContent);
+        if ($teamcityContent !== null) {
+            $this->output->write(OutputFormatter::escape($teamcityContent));
         } elseif ($this->options->testdox()) {
             $this->processTestdoxReader($reader->getSuite());
         } else {
@@ -725,7 +725,7 @@ final class ResultPrinter
             $lines    = explode("\n", $case->text);
             $lines[0] = '';
             if ($case instanceof SkippedTestCase) {
-                unset($lines[1]);
+                unset($lines[0]);
             }
 
             $lines[] = '';

--- a/src/Runners/PHPUnit/ResultPrinter.php
+++ b/src/Runners/PHPUnit/ResultPrinter.php
@@ -5,9 +5,19 @@ declare(strict_types=1);
 namespace ParaTest\Runners\PHPUnit;
 
 use InvalidArgumentException;
+use ParaTest\Logging\JUnit\ErrorTestCase;
+use ParaTest\Logging\JUnit\FailureTestCase;
 use ParaTest\Logging\JUnit\Reader;
+use ParaTest\Logging\JUnit\RiskyTestCase;
+use ParaTest\Logging\JUnit\SkippedTestCase;
+use ParaTest\Logging\JUnit\SuccessTestCase;
+use ParaTest\Logging\JUnit\TestCaseWithMessage;
+use ParaTest\Logging\JUnit\TestSuite;
+use ParaTest\Logging\JUnit\WarningTestCase;
 use ParaTest\Logging\LogInterpreter;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Util\Color;
+use PHPUnit\Util\TestDox\NamePrettifier;
 use SebastianBergmann\CodeCoverage\Driver\Selector;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
@@ -17,13 +27,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function array_filter;
 use function array_map;
 use function assert;
+use function class_exists;
 use function count;
+use function explode;
 use function fclose;
 use function file_get_contents;
 use function filesize;
 use function floor;
 use function fopen;
 use function fwrite;
+use function get_class;
 use function implode;
 use function is_array;
 use function max;
@@ -46,12 +59,14 @@ use const PHP_VERSION;
  */
 final class ResultPrinter
 {
-    /**
-     * A collection of ExecutableTest objects.
-     *
-     * @var ExecutableTest[]
-     */
-    private $suites = [];
+    private const TESTDOX_SYMBOLS = [
+        SuccessTestCase::class => '✔',
+        ErrorTestCase::class  => '✘',
+        FailureTestCase::class => '✘',
+        SkippedTestCase::class => '↩',
+        RiskyTestCase::class  => '☢',
+        WarningTestCase::class => '⚠',
+    ];
 
     /** @var LogInterpreter */
     private $results;
@@ -148,7 +163,6 @@ final class ResultPrinter
      */
     public function addTest(ExecutableTest $suite): void
     {
-        $this->suites[]    = $suite;
         $this->totalCases += $suite->getTestCount();
     }
 
@@ -163,7 +177,7 @@ final class ResultPrinter
                          + (DIRECTORY_SEPARATOR === '\\' ? -1 : 0) // fix windows blank lines
                          - strlen($this->getProgress());
 
-        if ($this->options->verbosity() >= Options::VERBOSITY_VERBOSE) {
+        if ($this->options->verbose()) {
             // @see \PHPUnit\TextUI\TestRunner::writeMessage()
             $output = $this->output;
             $write  = static function (string $type, string $message) use ($output): void {
@@ -226,7 +240,7 @@ final class ResultPrinter
             $this->getFailures(),
             $this->getRisky(),
         ];
-        if ($this->options->verbosity() >= Options::VERBOSITY_VERBOSE) {
+        if ($this->options->verbose()) {
             $toFilter[] = $this->getSkipped();
         }
 
@@ -264,6 +278,7 @@ final class ResultPrinter
             );
         }
 
+        $teamcityContent = null;
         if ($this->needsTeamcity) {
             $teamcityLogFile = $test->getTeamcityTempFile();
 
@@ -271,21 +286,21 @@ final class ResultPrinter
                 throw new EmptyLogFileException("Teamcity format file {$teamcityLogFile} is empty");
             }
 
-            $result = file_get_contents($teamcityLogFile);
-            assert($result !== false);
+            $teamcityContent = file_get_contents($teamcityLogFile);
+            assert($teamcityContent !== false);
 
             if ($this->teamcityLogFileHandle !== null) {
-                fwrite($this->teamcityLogFileHandle, $result);
-            }
-
-            if ($this->printsTeamcity) {
-                $this->output->write($result);
+                fwrite($this->teamcityLogFileHandle, $teamcityContent);
             }
         }
 
         $this->results->addReader($reader);
 
-        if (! $this->printsTeamcity) {
+        if ($teamcityContent !== null && $this->printsTeamcity) {
+            $this->output->write($teamcityContent);
+        } elseif ($this->options->testdox()) {
+            $this->processTestdoxReader($reader->getSuite());
+        } else {
             $this->processReaderFeedback($reader, $test->getTestCount());
         }
 
@@ -660,5 +675,68 @@ final class ResultPrinter
         }
 
         return implode(PHP_EOL, $styledLines);
+    }
+
+    private function processTestdoxReader(TestSuite $testSuite): void
+    {
+        foreach ($testSuite->suites as $suite) {
+            $this->processTestdoxReader($suite);
+        }
+
+        if ($testSuite->cases === []) {
+            return;
+        }
+
+        $prettifier = new NamePrettifier(false);
+
+        $class = $testSuite->name;
+        assert(class_exists($class));
+
+        $this->output->writeln($prettifier->prettifyTestClass($class));
+
+        $separator = PHP_EOL;
+        foreach ($testSuite->cases as $case) {
+            $separator = PHP_EOL;
+            $testCase  = new $class($case->name);
+            assert($testCase instanceof TestCase);
+
+            $time = '';
+            if ($this->options->verbose()) {
+                $time = sprintf(' [%.2f ms]', $case->time * 1000);
+            }
+
+            $testName = $prettifier->prettifyTestCase($testCase);
+            $this->output->writeln(sprintf(
+                ' %s %s%s',
+                self::TESTDOX_SYMBOLS[get_class($case)],
+                $testName,
+                $time
+            ));
+
+            $failingCase = $case instanceof FailureTestCase || $case instanceof ErrorTestCase || $case instanceof WarningTestCase;
+            if (! $this->options->verbose() && ! $failingCase) {
+                continue;
+            }
+
+            if (! $case instanceof TestCaseWithMessage) {
+                continue;
+            }
+
+            $lines    = explode("\n", $case->text);
+            $lines[0] = '';
+            if ($case instanceof SkippedTestCase) {
+                unset($lines[1]);
+            }
+
+            $lines[] = '';
+            foreach ($lines as $index => $line) {
+                $lines[$index] = '   │' . ($line !== '' ? ' ' . $line : '');
+            }
+
+            $this->output->writeln(implode(PHP_EOL, $lines) . PHP_EOL);
+            $separator = '';
+        }
+
+        $this->output->write($separator);
     }
 }

--- a/src/Runners/PHPUnit/Runner.php
+++ b/src/Runners/PHPUnit/Runner.php
@@ -69,7 +69,7 @@ final class Runner extends BaseRunner
             $this->running[$token] = new RunnerWorker($executableTest, $this->options, $token);
             $this->running[$token]->run();
 
-            if ($this->options->verbosity() < Options::VERBOSITY_VERY_VERBOSE) {
+            if (! $this->options->debug()) {
                 continue;
             }
 

--- a/src/Runners/PHPUnit/Worker/WrapperWorker.php
+++ b/src/Runners/PHPUnit/Worker/WrapperWorker.php
@@ -93,7 +93,7 @@ final class WrapperWorker
         $parameters[] = '--write-to';
         $parameters[] = $this->writeToPathname;
 
-        if ($options->verbosity() >= Options::VERBOSITY_VERY_VERBOSE) {
+        if ($options->debug()) {
             $this->output->write(sprintf(
                 "Starting WrapperWorker via: %s\n",
                 implode(' ', array_map('\escapeshellarg', $parameters))
@@ -136,7 +136,7 @@ final class WrapperWorker
         assert($this->currentlyExecuting === null);
         $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru());
         $command          = implode(' ', array_map('\\escapeshellarg', $commandArguments));
-        if ($options->verbosity() >= Options::VERBOSITY_VERY_VERBOSE) {
+        if ($options->debug()) {
             $this->output->write("\nExecuting test via: {$command}\n");
         }
 

--- a/src/Runners/PHPUnit/WrapperRunner.php
+++ b/src/Runners/PHPUnit/WrapperRunner.php
@@ -36,7 +36,6 @@ final class WrapperRunner extends BaseRunner
     {
         $this->startWorkers();
         $this->assignAllPendingTests();
-        $this->sendStopMessages();
         $this->waitForAllToFinish();
     }
 
@@ -103,18 +102,17 @@ final class WrapperRunner extends BaseRunner
         $this->exitcode = max($this->exitcode, $exitCode);
     }
 
-    private function sendStopMessages(): void
-    {
-        foreach ($this->workers as $worker) {
-            $worker->stop();
-        }
-    }
-
     private function waitForAllToFinish(): void
     {
+        $stopped = [];
         while (count($this->workers) > 0) {
             foreach ($this->workers as $index => $worker) {
                 if ($worker->isRunning()) {
+                    if (! isset($stopped[$index]) && $worker->isFree()) {
+                        $worker->stop();
+                        $stopped[$index] = true;
+                    }
+
                     continue;
                 }
 

--- a/test/Unit/Coverage/CoverageMergerTest.php
+++ b/test/Unit/Coverage/CoverageMergerTest.php
@@ -38,7 +38,7 @@ final class CoverageMergerTest extends TestBase
         // Every time the two above files are changed, the line numbers
         // may change, and so these two numbers may need adjustments
         $firstFileFirstLine  = 67;
-        $secondFileFirstLine = 37;
+        $secondFileFirstLine = 36;
 
         $filter = new Filter();
         $filter->includeFiles([$firstFile, $secondFile]);

--- a/test/Unit/Logging/JUnit/WriterTest.php
+++ b/test/Unit/Logging/JUnit/WriterTest.php
@@ -23,6 +23,7 @@ use function unlink;
  * @covers \ParaTest\Logging\JUnit\RiskyTestCase
  * @covers \ParaTest\Logging\JUnit\SkippedTestCase
  * @covers \ParaTest\Logging\JUnit\WarningTestCase
+ * @covers \ParaTest\Logging\JUnit\TestCaseWithMessage
  * @covers \ParaTest\Logging\JUnit\Writer
  */
 final class WriterTest extends TestBase

--- a/test/Unit/Logging/JUnit/WriterTest.php
+++ b/test/Unit/Logging/JUnit/WriterTest.php
@@ -18,6 +18,11 @@ use function unlink;
 /**
  * @internal
  *
+ * @covers \ParaTest\Logging\JUnit\ErrorTestCase
+ * @covers \ParaTest\Logging\JUnit\FailureTestCase
+ * @covers \ParaTest\Logging\JUnit\RiskyTestCase
+ * @covers \ParaTest\Logging\JUnit\SkippedTestCase
+ * @covers \ParaTest\Logging\JUnit\WarningTestCase
  * @covers \ParaTest\Logging\JUnit\Writer
  */
 final class WriterTest extends TestBase

--- a/test/Unit/Logging/LogInterpreterTest.php
+++ b/test/Unit/Logging/LogInterpreterTest.php
@@ -115,11 +115,21 @@ final class LogInterpreterTest extends ResultTester
             . "\n"
             . './test/fixtures/failing_tests/UnitTestWithClassAnnotationTest.php:32',
             "ParaTest\\Tests\\fixtures\\failing_tests\\UnitTestWithErrorTest::testFalsehood\n"
-            . "Failed asserting that true is false.\n"
+            . "Failed asserting that two strings are identical.\n"
+            . "--- Expected\n"
+            . "+++ Actual\n"
+            . "@@ @@\n"
+            . "-'foo'\n"
+            . "+'bar'\n"
             . "\n"
             . './test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27',
             "ParaTest\\Tests\\fixtures\\failing_tests\\UnitTestWithMethodAnnotationsTest::testFalsehood\n"
-            . "Failed asserting that true is false.\n"
+            . "Failed asserting that two strings are identical.\n"
+            . "--- Expected\n"
+            . "+++ Actual\n"
+            . "@@ @@\n"
+            . "-'foo'\n"
+            . "+'bar'\n"
             . "\n"
             . './test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27',
         ];

--- a/test/Unit/Runners/PHPUnit/OptionsTest.php
+++ b/test/Unit/Runners/PHPUnit/OptionsTest.php
@@ -259,7 +259,8 @@ final class OptionsTest extends TestBase
         static::assertFalse($options->stopOnFailure());
         static::assertEmpty($options->testsuite());
         static::assertSame($this->tmpDir, $options->tmpDir());
-        static::assertSame(Options::VERBOSITY_NORMAL, $options->verbosity());
+        static::assertFalse($options->verbose());
+        static::assertFalse($options->debug());
         static::assertNull($options->whitelist());
         static::assertSame(Options::ORDER_DEFAULT, $options->orderBy());
         static::assertSame(0, $options->randomOrderSeed());
@@ -268,6 +269,7 @@ final class OptionsTest extends TestBase
         static::assertFalse($options->needsTeamcity());
         static::assertFalse($options->hasCoverage());
         static::assertSame(0, $options->repeat());
+        static::assertFalse($options->testdox());
     }
 
     public function testProvidedOptions(): void
@@ -303,11 +305,13 @@ final class OptionsTest extends TestBase
             '--stop-on-failure' => true,
             '--testsuite' => 'TESTSUITE',
             '--tmp-dir' => ($tmpDir = uniqid($this->tmpDir . DS . 't')),
-            '--verbose' => 2,
+            '--verbose' => true,
+            '--debug' => true,
             '--whitelist' => 'WHITELIST',
             '--order-by' => Options::ORDER_RANDOM,
             '--random-order-seed' => (string) $expected_random_seed,
             '--repeat' => '2',
+            '--testdox' => true,
         ];
 
         $options = $this->createOptionsFromArgv($argv, __DIR__);
@@ -343,11 +347,13 @@ final class OptionsTest extends TestBase
         static::assertTrue($options->stopOnFailure());
         static::assertSame(['TESTSUITE'], $options->testsuite());
         static::assertSame($tmpDir, $options->tmpDir());
-        static::assertSame(Options::VERBOSITY_VERY_VERBOSE, $options->verbosity());
+        static::assertTrue($options->verbose());
+        static::assertTrue($options->debug());
         static::assertSame('WHITELIST', $options->whitelist());
         static::assertSame(Options::ORDER_RANDOM, $options->orderBy());
         static::assertSame($expected_random_seed, $options->randomOrderSeed());
         static::assertSame(2, $options->repeat());
+        static::assertTrue($options->testdox());
 
         static::assertSame([
             'bootstrap' => 'BOOTSTRAP',
@@ -367,9 +373,8 @@ final class OptionsTest extends TestBase
 
     public function testSingleVerboseFlag(): void
     {
-        $options = $this->createOptionsFromArgv(['--verbose' => 1], __DIR__);
-
-        static::assertSame(Options::VERBOSITY_VERBOSE, $options->verbosity());
+        static::assertFalse($this->createOptionsFromArgv(['--verbose' => false], __DIR__)->verbose());
+        static::assertTrue($this->createOptionsFromArgv(['--verbose' => true], __DIR__)->verbose());
     }
 
     public function testGatherOptionsFromConfiguration(): void

--- a/test/Unit/Runners/PHPUnit/RunnerTestCase.php
+++ b/test/Unit/Runners/PHPUnit/RunnerTestCase.php
@@ -124,7 +124,7 @@ abstract class RunnerTestCase extends TestBase
             '--configuration' => $this->fixture('phpunit-parallel-suite.xml'),
             '--parallel-suite' => true,
             '--processes' => '2',
-            '--verbose' => 1,
+            '--verbose' => true,
             '--whitelist' => $this->fixture('parallel_suite'),
         ]);
 
@@ -480,7 +480,7 @@ abstract class RunnerTestCase extends TestBase
             '--configuration' => $this->fixture('phpunit-passing.xml'),
             '--order-by' => Options::ORDER_RANDOM,
             '--random-order-seed' => '123',
-            '--verbose' => 2,
+            '--debug' => true,
         ];
 
         $runnerResultFirst  = $this->runRunner();
@@ -519,7 +519,7 @@ abstract class RunnerTestCase extends TestBase
     {
         $this->bareOptions = [
             '--configuration' => $this->fixture('phpunit-passing.xml'),
-            '--verbose' => 2,
+            '--debug' => true,
         ];
 
         $runnerResult = $this->runRunner();

--- a/test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php
+++ b/test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php
@@ -24,7 +24,7 @@ class UnitTestWithMethodAnnotationsTest extends TestCase
      */
     public function testFalsehood(): void
     {
-        $this->assertFalse(true);
+        $this->assertSame('foo', 'bar');
     }
 
     /**

--- a/test/fixtures/results/junit-example-result.xml
+++ b/test/fixtures/results/junit-example-result.xml
@@ -22,7 +22,12 @@ RuntimeException: Error!!!
       <testcase name="isItFalse" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithErrorTest" file="./test/fixtures/failing_tests/UnitTestWithErrorTest.php" line="27" assertions="1" time="1.234567"/>
       <testcase name="testFalsehood" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithErrorTest" file="./test/fixtures/failing_tests/UnitTestWithErrorTest.php" line="25" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest::testFalsehood
-Failed asserting that true is false.
+Failed asserting that two strings are identical.
+--- Expected
++++ Actual
+@@ @@
+-'foo'
++'bar'
 
 ./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27</failure>
       </testcase>

--- a/test/fixtures/results/mixed-results.xml
+++ b/test/fixtures/results/mixed-results.xml
@@ -22,7 +22,12 @@ RuntimeException: Error!!!
       <testcase name="isItFalse" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithErrorTest" file="./test/fixtures/failing_tests/UnitTestWithErrorTest.php" line="27" assertions="1" time="1.234567"/>
       <testcase name="testFalsehood" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithErrorTest" file="./test/fixtures/failing_tests/UnitTestWithErrorTest.php" line="25" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\failing_tests\UnitTestWithErrorTest::testFalsehood
-Failed asserting that true is false.
+Failed asserting that two strings are identical.
+--- Expected
++++ Actual
+@@ @@
+-'foo'
++'bar'
 
 ./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27</failure>
       </testcase>
@@ -48,7 +53,12 @@ This test did not perform any assertions
       <testcase name="testTruth" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithMethodAnnotationsTest" file="./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php" line="17" assertions="1" time="1.234567"/>
       <testcase name="testFalsehood" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithMethodAnnotationsTest" file="./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php" line="25" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest::testFalsehood
-Failed asserting that true is false.
+Failed asserting that two strings are identical.
+--- Expected
++++ Actual
+@@ @@
+-'foo'
++'bar'
 
 ./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27</failure>
       </testcase>

--- a/test/fixtures/results/single-wfailure.xml
+++ b/test/fixtures/results/single-wfailure.xml
@@ -4,7 +4,12 @@
     <testcase name="testTruth" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithMethodAnnotationsTest" file="./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php" line="17" assertions="1" time="1.234567"/>
     <testcase name="testFalsehood" class="ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest" classname="ParaTest.Tests.fixtures.failing_tests.UnitTestWithMethodAnnotationsTest" file="./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php" line="25" assertions="1" time="1.234567">
       <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\failing_tests\UnitTestWithMethodAnnotationsTest::testFalsehood
-Failed asserting that true is false.
+Failed asserting that two strings are identical.
+--- Expected
++++ Actual
+@@ @@
+-'foo'
++'bar'
 
 ./test/fixtures/failing_tests/UnitTestWithMethodAnnotationsTest.php:27</failure>
     </testcase>


### PR DESCRIPTION
Fixes https://github.com/paratestphp/paratest/issues/250, https://github.com/paratestphp/paratest/issues/396, https://github.com/paratestphp/paratest/issues/633

This PR:

- [x] Add TestDox support
- [x] Fixes `--verbose` option type
- [x] Add `--debug` option