### PR TITLE
Reader: fix getFeedback() for tests with multiple failures

### DIFF
--- a/src/Logging/JUnit/Reader.php
+++ b/src/Logging/JUnit/Reader.php
@@ -107,12 +107,12 @@ final class Reader implements MetaProviderInterface
             . str_repeat('S', $this->suite->skipped)
             . str_repeat(
                 '.',
-                $this->suite->tests
-                - $this->suite->errors
-                - $this->suite->warnings
-                - $this->suite->failures
-                - $this->suite->risky
-                - $this->suite->skipped,
+                ($successTimes = $this->suite->tests
+                    - $this->suite->errors
+                    - $this->suite->warnings
+                    - $this->suite->failures
+                    - $this->suite->risky
+                    - $this->suite->skipped) >= 0 ? $successTimes : 0,
             );
     }
 


### PR DESCRIPTION
I've got following test, with no assertions added yet:

```php
use PHPUnit\Framework\TestCase;

final class FormsMonitorExtensionTest extends TestCase
{

	public function testNotEnabled(): void
	{
		$configurator = new ManualConfigurator(dirname(__DIR__, 6));
		$configurator->setForceReloadContainer();
		$configurator->addConfig(__DIR__ . '/FormsMonitorExtension.notEnabled.neon');

		$container = $configurator->createContainer();

	}

}
```

It resulted in following error:

```txt
ParaTest v6.6.0 upon PHPUnit 9.5.21 #StandWithUkraine

...PHP Fatal error:  Uncaught ValueError: str_repeat(): Argument #2 ($times) must be greater than or equal to 0 in /path/vendor/brianium/paratest/src/Logging/JUnit/Reader.php:115
Stack trace:
#0 /path/vendor/brianium/paratest/src/Logging/JUnit/Reader.php(115): str_repeat()
#1 /path/vendor/brianium/paratest/src/Runners/PHPUnit/ResultPrinter.php(402): ParaTest\Logging\JUnit\Reader->getFeedback()
#2 /path/vendor/brianium/paratest/src/Runners/PHPUnit/ResultPrinter.php(304): ParaTest\Runners\PHPUnit\ResultPrinter->processReaderFeedback()
#3 /path/vendor/brianium/paratest/src/Runners/PHPUnit/Worker/WrapperWorker.php(158): ParaTest\Runners\PHPUnit\ResultPrinter->printFeedback()
#4 /path/vendor/brianium/paratest/src/Runners/PHPUnit/WrapperRunner.php(79): ParaTest\Runners\PHPUnit\Worker\WrapperWorker->printFeedback()
#5 /path/vendor/brianium/paratest/src/Runners/PHPUnit/WrapperRunner.php(123): ParaTest\Runners\PHPUnit\WrapperRunner->flushWorker()
#6 /path/vendor/brianium/paratest/src/Runners/PHPUnit/WrapperRunner.php(39): ParaTest\Runners\PHPUnit\WrapperRunner->waitForAllToFinish()
#7 /path/vendor/brianium/paratest/src/Runners/PHPUnit/BaseRunner.php(82): ParaTest\Runners\PHPUnit\WrapperRunner->doRun()
#8 /path/vendor/brianium/paratest/src/Console/Commands/ParaTestCommand.php(103): ParaTest\Runners\PHPUnit\BaseRunner->run()
#9 /path/vendor/symfony/console/Command/Command.php(308): ParaTest\Console\Commands\ParaTestCommand->execute()
#10 /path/vendor/symfony/console/Application.php(998): Symfony\Component\Console\Command\Command->run()
#11 /path/vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application->doRunCommand()
#12 /path/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun()
#13 /path/vendor/brianium/paratest/bin/paratest(37): Symfony\Component\Console\Application->run()
#14 /path/vendor/bin/paratest(117): include('...')
#15 {main}
  thrown in /path/vendor/brianium/paratest/src/Logging/JUnit/Reader.php on line 115
```

After fix I get:

```txt
ParaTest v6.6.0 upon PHPUnit 9.5.21 #StandWithUkraine

.....ER                                                             7 / 7 (100%)

Time: 00:00.249, Memory: 10.00 MB

There was 1 risky:

1) FormsMonitorExtensionTest::testNotEnabled
This test did not perform any assertions

/path/tests/Unit/FormsMonitorExtensionTest.php:11
```

Both `E` and `R` problems were produced by the unfinished test, other tests are successful. I believe this was cause of negative number used in `str_repeat()`