### PR TITLE
Fixes for phpstormhelper to do with re-running failed tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
         "ext-reflection": "*",
         "ext-simplexml": "*",
         "jean85/pretty-package-versions": "^2.0.5",
-        "phpunit/php-code-coverage": "^9.2.16",
+        "phpunit/php-code-coverage": "^9.2.17",
         "phpunit/php-file-iterator": "^3.0.6",
         "phpunit/php-timer": "^5.0.3",
-        "phpunit/phpunit": "^9.5.23",
+        "phpunit/phpunit": "^9.5.24",
         "sebastian/environment": "^5.1.4",
         "symfony/console": "^5.4.12 || ^6.1.4",
         "symfony/polyfill-php80": "^v1.26.0",
@@ -52,11 +52,11 @@
         "ext-pcov": "*",
         "ext-posix": "*",
         "doctrine/coding-standard": "^10.0.0",
-        "infection/infection": "^0.26.13",
+        "infection/infection": "^0.26.14",
         "malukenho/mcbumpface": "^1.1.5",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/filesystem": "^5.4.12 || ^6.1.4",
-        "vimeo/psalm": "^4.26.0"
+        "vimeo/psalm": "^4.27.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Util/PhpstormHelper.php
+++ b/src/Util/PhpstormHelper.php
@@ -7,9 +7,15 @@ namespace ParaTest\Util;
 use RuntimeException;
 
 use function array_search;
+use function array_unshift;
+use function dirname;
 use function in_array;
+use function realpath;
 use function strlen;
+use function substr;
 use function substr_compare;
+
+use const DIRECTORY_SEPARATOR;
 
 /** @internal */
 final class PhpstormHelper
@@ -17,9 +23,6 @@ final class PhpstormHelper
     /** @param  array<int, string> $argv */
     public static function handleArgvFromPhpstorm(array &$argv, string $paratestBinary): string
     {
-        // Remove the helper file so it is not re-included
-        unset($argv[self::getArgvKeyFor($argv, '/paratest_for_phpstorm')]);
-
         $phpunitKey = self::getArgvKeyFor($argv, '/phpunit');
 
         if (! in_array('--filter', $argv, true)) {
@@ -33,8 +36,8 @@ final class PhpstormHelper
             return $paratestBinary;
         }
 
+        unset($argv[self::getArgvKeyFor($argv, '/paratest_for_phpstorm')]);
         $phpunitBinary = $argv[$phpunitKey];
-        unset($argv[self::getArgvKeyFor($argv, '/phpunit')]);
         foreach ($argv as $index => $value) {
             if ($value === '--configuration' || $value === '--bootstrap') {
                 break;
@@ -42,6 +45,8 @@ final class PhpstormHelper
 
             unset($argv[$index]);
         }
+
+        array_unshift($argv, $phpunitBinary);
 
         return $phpunitBinary;
     }

--- a/src/Util/PhpstormHelper.php
+++ b/src/Util/PhpstormHelper.php
@@ -7,7 +7,6 @@ namespace ParaTest\Util;
 use RuntimeException;
 
 use function array_search;
-use function array_unshift;
 use function in_array;
 use function str_ends_with;
 
@@ -17,6 +16,9 @@ final class PhpstormHelper
     /** @param  array<int, string> $argv */
     public static function handleArgvFromPhpstorm(array &$argv, string $paratestBinary): string
     {
+        // Remove the helper file so it is not re-included
+        unset($argv[self::getArgvKeyFor($argv, '/paratest_for_phpstorm')]);
+
         $phpunitKey = self::getArgvKeyFor($argv, '/phpunit');
 
         if (! in_array('--filter', $argv, true)) {
@@ -30,8 +32,8 @@ final class PhpstormHelper
             return $paratestBinary;
         }
 
-        unset($argv[self::getArgvKeyFor($argv, 'vendor/brianium/paratest/bin/paratest')]);
         $phpunitBinary = $argv[$phpunitKey];
+        unset($argv[self::getArgvKeyFor($argv, '/phpunit')]);
         foreach ($argv as $index => $value) {
             if ($value === '--configuration' || $value === '--bootstrap') {
                 break;
@@ -39,8 +41,6 @@ final class PhpstormHelper
 
             unset($argv[$index]);
         }
-
-        array_unshift($argv, $phpunitBinary);
 
         return $phpunitBinary;
     }

--- a/src/Util/PhpstormHelper.php
+++ b/src/Util/PhpstormHelper.php
@@ -8,14 +8,9 @@ use RuntimeException;
 
 use function array_search;
 use function array_unshift;
-use function dirname;
 use function in_array;
-use function realpath;
 use function strlen;
-use function substr;
 use function substr_compare;
-
-use const DIRECTORY_SEPARATOR;
 
 /** @internal */
 final class PhpstormHelper

--- a/test/Unit/Util/PhpstormHelperTest.php
+++ b/test/Unit/Util/PhpstormHelperTest.php
@@ -74,6 +74,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpStormHelperBinary;
         $expectedArgv[] = '--configuration';
         $expectedArgv[] = '/home/user/repos/test/phpunit.xml';
         $expectedArgv[] = '--teamcity';
@@ -101,6 +102,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpStormHelperBinary;
         $expectedArgv[] = '--runner';
         $expectedArgv[] = 'WrapperRunner';
         $expectedArgv[] = '--configuration';
@@ -132,6 +134,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpunitBinary;
         $expectedArgv[] = '--configuration';
         $expectedArgv[] = '/home/user/repos/test/phpunit.xml';
         $expectedArgv[] = '--filter';
@@ -163,6 +166,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpunitBinary;
         $expectedArgv[] = '--configuration';
         $expectedArgv[] = '/home/user/repos/test/phpunit.xml';
         $expectedArgv[] = '--filter';
@@ -193,6 +197,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpStormHelperBinary;
         $expectedArgv[] = '--coverage-clover';
         $expectedArgv[] = '/home/user/repos/test/coverage.xml';
         $expectedArgv[] = '--configuration';
@@ -224,6 +229,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpStormHelperBinary;
         $expectedArgv[] = '--passthru-php=\'-d\' \'pcov.enabled=1\'';
         $expectedArgv[] = '--coverage-clover';
         $expectedArgv[] = '/home/user/repos/test/coverage.xml';
@@ -252,6 +258,7 @@ final class PhpstormHelperTest extends TestCase
         $argv[] = '--teamcity';
 
         $expectedArgv   = [];
+        $expectedArgv[] = $phpStormHelperBinary;
         $expectedArgv[] = '--configuration';
         $expectedArgv[] = '/home/user/repos/test/phpunit.xml';
         $expectedArgv[] = '--teamcity';


### PR DESCRIPTION
I have been getting console messages caused by the previous code I contributed when using the "re-run failed tests" button. This PR resolves those errors. I would really appreciate another set of eyes on this as well, as some of the removed code didn't seem to serve a purpose and I wanted to make sure there wasn't a use-case I was missing.

Also re-write for the util test to have more documentation and better-explained test cases