### PR TITLE
Integrate FidryCpuCoreCounter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
+        "fidry/cpu-core-counter": "^0.4.0",
         "jean85/pretty-package-versions": "^2.0.5",
         "phpunit/php-code-coverage": "^9.2.19",
         "phpunit/php-file-iterator": "^3.0.6",


### PR DESCRIPTION
See https://github.com/theofidry/cpu-core-counter/issues/11 for the motivations.

The code should be sensibly the same, the notable differences are:

- fixed the deprecated usage of `hw.ncpu`
- /proc/cpuinfo is check _last_
- nproc is checked first (before was not checked at all, it's considered to be more accurate and less convoluted than cpuinfo though)

I would also wait on 1.x before merging this if you're happy with it. Technically the current version is fine, I'm just looking for a round of feedback before publishing 1.0.

