### PR TITLE
Fix fidry/cpu-core-counter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "fidry/cpu-core-counter": "^0.5.1",
+        "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
         "jean85/pretty-package-versions": "^2.0.5",
         "phpunit/php-code-coverage": "^10.0",
         "phpunit/php-file-iterator": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pcre": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "fidry/cpu-core-counter": "^0.5.1 || ^0.5.1",
+        "fidry/cpu-core-counter": "^0.5.1",
         "jean85/pretty-package-versions": "^2.0.5",
         "phpunit/php-code-coverage": "^10.0",
         "phpunit/php-file-iterator": "^4.0",


### PR DESCRIPTION
The `||` used in equal value `^0.5.1 || ^0.5.1`, so it can just use the value directly.