### PR TITLE
Add support to PHP 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
         dependencies:
           - "lowest"
           - "highest"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-pcre": "*",
         "ext-reflection": "*",
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.1",
         "phpunit/php-file-iterator": "^4.0.1",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": "^10.1.2",
+        "phpunit/phpunit": ">= 10.1.2 <10.2",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.2.10",
         "symfony/process": "^6.2.10"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.1",
         "phpunit/php-file-iterator": "^4.0.2",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": ">= 10.1.2 <10.2",
+        "phpunit/phpunit": "^10.1.2",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.3.0",
         "symfony/process": "^6.3.0"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.1",
         "phpunit/php-file-iterator": "^4.0.2",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": "^10.1.2",
+        "phpunit/phpunit": "^10.2.2",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.3.0",
         "symfony/process": "^6.3.0"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-pcre": "*",
         "ext-reflection": "*",
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.1",
         "phpunit/php-file-iterator": "^4.0.2",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": "^10.2.2",
+        "phpunit/phpunit": "^10.1.2",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.3.0",
         "symfony/process": "^6.3.0"


### PR DESCRIPTION
Hi everyone,
I tried to update the dependencies for PHP 8.3.
I also update the GitHub actions workflow for running tests with php8.3
One note about phpunit10.2: because phpunit10.2 introduces some breaking changes, I added 
```
 "phpunit/phpunit": ">= 10.1.2 <10.2"
```
in the composer. json.
But this is a new issue (not strictly related to PHP8.3), which is why another PR should address the support for phpunit10.2.


Please feel free to give me any feedback you might have.

Roberto