### PR TITLE
Allow Symfony 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,38 @@ jobs:
         timeout-minutes: 3
         run: "vendor/bin/phpunit --no-coverage --no-logging"
 
+  tests-symfony-7:
+    name: "Tests for Symfony 7"
+    runs-on: "ubuntu-latest"
+    env:
+      SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.2"
+        symfony-version:
+          - "7.x-dev"
+
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "pcov"
+          php-version: "${{ matrix.php-version }}"
+          ini-values: "${{ env.INI_VALUES }}"
+
+      - name: "Install Symfony Flex"
+        run: |
+          composer config --global --no-plugins allow-plugins.symfony/flex true
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+
+      - uses: "ramsey/composer-install@v2"
+
+      - name: "Run tests"
+        timeout-minutes: 3
+        run: "vendor/bin/phpunit --no-coverage --no-logging"
+
   code-coverage:
     name: "Code Coverage"
     runs-on: "ubuntu-latest"

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "phpunit/php-timer": "^6.0",
         "phpunit/phpunit": "^10.2.6",
         "sebastian/environment": "^6.0.1",
-        "symfony/console": "^6.3.0",
-        "symfony/process": "^6.3.0"
+        "symfony/console": "^6.3.0 || ^7.0",
+        "symfony/process": "^6.3.0 || ^7.0"
     },
     "require-dev": {
         "ext-pcov": "*",
@@ -58,7 +58,7 @@
         "phpstan/phpstan-phpunit": "^1.3.13",
         "phpstan/phpstan-strict-rules": "^1.5.1",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "symfony/filesystem": "^6.3.1"
+        "symfony/filesystem": "^6.3.1 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,

This PR allows packages relying on Paratest to upgrade their dependencies to Symfony 7.

I added a separate workflow section to test specifically against Symfony 7 on Paratest, and it seems to pass.