### PR TITLE
Set `PHPUNIT_COMPOSER_INSTALL` before requiring the autoloader so it can access it

### DIFF
--- a/bin/phpunit-wrapper.php
+++ b/bin/phpunit-wrapper.php
@@ -15,8 +15,8 @@ use ParaTest\Runners\PHPUnit\Worker\WrapperWorker;
 
     foreach ($composerAutoloadFiles as $file) {
         if (file_exists($file)) {
-            require_once $file;
             define('PHPUNIT_COMPOSER_INSTALL', $file);
+            require_once $file;
 
             break;
         }


### PR DESCRIPTION
Fixes https://github.com/paratestphp/paratest/issues/793

Some guidance would be appreciated if we want to test this fix..!