### PR TITLE
Fix problem with untrimmed command

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -106,6 +106,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         dependencies:
           - "lowest"
           - "highest"

--- a/bin/phpunit-wrapper.php
+++ b/bin/phpunit-wrapper.php
@@ -38,7 +38,7 @@ use ParaTest\Runners\PHPUnit\Worker\WrapperWorker;
             exit;
         }
 
-        $arguments = unserialize($command);
+        $arguments = unserialize(trim($command));
         (new PHPUnit\TextUI\Command())->run($arguments, false);
 
         fwrite($writeTo, WrapperWorker::TEST_EXECUTED_MARKER);


### PR DESCRIPTION
After update to PHP 8.3 I got the following warnings in the `bin/phpunit-wrapper.php`:
```
Warning: unserialize(): Extra data starting at offset 534 of 535 bytes in /Users/xxx/Projects/xxx/vendor/brianium/paratest/bin/phpunit-wrapper.php on line 41
```

Trimming the command helped there.