### PR TITLE
Use a wrapper test suite to avoid TestSuiteLoader problems

### DIFF
--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -9,8 +9,13 @@ use ParaTest\Runners\PHPUnit\Worker\NullPhpunitPrinter;
 use function array_map;
 use function array_merge;
 use function assert;
+use function file_put_contents;
+use function sha1;
+use function sprintf;
 use function tempnam;
 use function unlink;
+
+use const DIRECTORY_SEPARATOR;
 
 abstract class ExecutableTest
 {
@@ -20,6 +25,9 @@ abstract class ExecutableTest
      * @var string
      */
     private $path;
+
+    /** @var string */
+    private $class;
 
     /**
      * A path to the temp JUnit file created
@@ -44,6 +52,9 @@ abstract class ExecutableTest
      */
     private $tempTeamcity;
 
+	/** @var string|null */
+	private $tempWrapperClass = null;
+
     /**
      * Last executed process command.
      *
@@ -58,9 +69,10 @@ abstract class ExecutableTest
     /** @var string */
     private $tmpDir;
 
-    public function __construct(string $path, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
+    public function __construct(string $path, string $class, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
         $this->path          = $path;
+        $this->class         = $class;
         $this->needsCoverage = $needsCoverage;
         $this->needsTeamcity = $needsTeamcity;
         $this->tmpDir        = $tmpDir;
@@ -79,7 +91,48 @@ abstract class ExecutableTest
         return $this->path;
     }
 
-    private function touchTempFile(?string &$tempName, string $prefix): string
+    /**
+     * PHPUnit doesn't like loading test classes which are already loaded.
+     * It normally only loads the test suite once so it considers this an error.
+     * This gets around that by generating a dynamic test suite for each test class
+     */
+    private function getWrappedPath(): string
+    {
+        if ($this->class === '') {
+            return $this->getPath();
+        }
+
+        $testSuiteClassName     = 'TestSuite' . sha1($this->class);
+        $this->tempWrapperClass = $this->tmpDir . DIRECTORY_SEPARATOR . $testSuiteClassName . '.php';
+
+        $template = <<<EOF
+        <?php
+        class %s {
+            public static function suite() {
+                if (!class_exists('%s')) {
+                    include_once('%s');
+                }
+                return new \PHPUnit\Framework\TestSuite(new \ReflectionClass('%s'));
+            }
+        }
+        EOF;
+        file_put_contents($this->tempWrapperClass, sprintf(
+            $template,
+            $testSuiteClassName,
+            $this->class,
+            $this->path,
+            $this->class
+        ));
+
+        return $this->tempWrapperClass;
+    }
+
+    final public function deleteWrappedTestSuite(): void
+    {
+        $this->unlinkTempFile($this->tempWrapperClass);
+    }
+
+	private function touchTempFile(?string &$tempName, string $prefix): string
     {
         if ($tempName === null) {
             $newFile = tempnam($this->tmpDir, $prefix);
@@ -119,6 +172,7 @@ abstract class ExecutableTest
         $this->unlinkTempFile($this->tempJUnit);
         $this->unlinkTempFile($this->tempTeamcity);
         $this->unlinkTempFile($this->coverageFileName);
+	    $this->unlinkTempFile($this->tempWrapperClass);
     }
 
   /**
@@ -147,7 +201,7 @@ abstract class ExecutableTest
      * @return string[] command line arguments
      * @psalm-return array<string>
      */
-    final public function commandArguments(string $binary, array $options, ?array $passthru): array
+	final public function commandArguments(string $binary, array $options, ?array $passthru, bool $wrap_test_suite = false): array
     {
         $options                = $this->prepareOptions($options);
         $options['no-logging']  = null;
@@ -178,7 +232,7 @@ abstract class ExecutableTest
             $arguments[] = $value;
         }
 
-        $arguments[] = $this->getPath();
+        $arguments[] = $wrap_test_suite ? $this->getWrappedPath() : $this->getPath();
         $arguments   = array_map('strval', $arguments);
 
         return $arguments;

--- a/src/Runners/PHPUnit/FullSuite.php
+++ b/src/Runners/PHPUnit/FullSuite.php
@@ -14,7 +14,7 @@ final class FullSuite extends ExecutableTest
 
     public function __construct(string $suiteName, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct('', $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct('', '', $needsCoverage, $needsTeamcity, $tmpDir);
 
         $this->suiteName = $suiteName;
     }

--- a/src/Runners/PHPUnit/Suite.php
+++ b/src/Runners/PHPUnit/Suite.php
@@ -24,9 +24,9 @@ final class Suite extends ExecutableTest
     private $functions;
 
     /** @param TestMethod[] $functions */
-    public function __construct(string $path, array $functions, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
+    public function __construct(string $path, string $class, array $functions, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($path, $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct($path, $class, $needsCoverage, $needsTeamcity, $tmpDir);
 
         $this->functions = $functions;
     }

--- a/src/Runners/PHPUnit/SuiteLoader.php
+++ b/src/Runners/PHPUnit/SuiteLoader.php
@@ -222,6 +222,7 @@ final class SuiteLoader
         foreach ($methodBatches as $methodBatch) {
             $executableTests[] = new TestMethod(
                 $path,
+                $class->getName(),
                 $methodBatch,
                 $this->options->hasCoverage(),
                 $this->options->needsTeamcity(),
@@ -390,6 +391,7 @@ final class SuiteLoader
     {
         return new Suite(
             $path,
+            $class->getName(),
             $this->executableTests(
                 $path,
                 $class,

--- a/src/Runners/PHPUnit/TestMethod.php
+++ b/src/Runners/PHPUnit/TestMethod.php
@@ -35,9 +35,9 @@ final class TestMethod extends ExecutableTest
      * @param string   $testPath path to phpunit test case file
      * @param string[] $filters  array of filters or single filter
      */
-    public function __construct(string $testPath, array $filters, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
+    public function __construct(string $testPath, string $class, array $filters, bool $needsCoverage, bool $needsTeamcity, string $tmpDir)
     {
-        parent::__construct($testPath, $needsCoverage, $needsTeamcity, $tmpDir);
+        parent::__construct($testPath, $class, $needsCoverage, $needsTeamcity, $tmpDir);
 
         // for compatibility with other code (tests), which can pass string (one filter)
         // instead of array of filters

--- a/src/Runners/PHPUnit/Worker/WrapperWorker.php
+++ b/src/Runners/PHPUnit/Worker/WrapperWorker.php
@@ -130,7 +130,7 @@ final class WrapperWorker
     public function assign(ExecutableTest $test, string $phpunit, array $phpunitOptions, Options $options): void
     {
         assert($this->currentlyExecuting === null);
-        $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru());
+        $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru(), true);
         $command          = implode(' ', array_map('\\escapeshellarg', $commandArguments));
         if ($options->debug()) {
             $this->output->write("\nExecuting test via: {$command}\n");
@@ -161,6 +161,10 @@ final class WrapperWorker
 
     public function reset(): void
     {
+        if ($this->currentlyExecuting !== null) {
+            $this->currentlyExecuting->deleteWrappedTestSuite();
+        }
+
         $this->currentlyExecuting = null;
     }
 

--- a/test/Unit/ResultTester.php
+++ b/test/Unit/ResultTester.php
@@ -68,10 +68,10 @@ EOF;
     {
         $functions = [];
         for ($i = 0; $i < $methodCount; ++$i) {
-            $functions[] = new TestMethod((string) $i, ['testMe'], false, true, $this->tmpDir);
+            $functions[] = new TestMethod((string) $i, '', ['testMe'], false, true, $this->tmpDir);
         }
 
-        $suite = new Suite('', $functions, false, true, $this->tmpDir);
+        $suite = new Suite('', '', $functions, false, true, $this->tmpDir);
         file_put_contents($suite->getTempFile(), (string) file_get_contents(FIXTURES . DS . 'results' . DS . $result));
         $teamcityData = 'no data';
         if ($result === 'single-passing.xml') {

--- a/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
+++ b/test/Unit/Runners/PHPUnit/ExecutableTestTest.php
@@ -21,7 +21,7 @@ final class ExecutableTestTest extends TestBase
 
     public function setUpTest(): void
     {
-        $this->executableTestChild = new ExecutableTestChild('pathToFile', true, true, $this->tmpDir);
+        $this->executableTestChild = new ExecutableTestChild('pathToFile', '', true, true, $this->tmpDir);
     }
 
     public function testConstructor(): void

--- a/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
+++ b/test/Unit/Runners/PHPUnit/ResultPrinterTest.php
@@ -94,10 +94,10 @@ final class ResultPrinterTest extends ResultTester
     {
         $funcs = [];
         for ($i = 0; $i < 120; ++$i) {
-            $funcs[] = new TestMethod((string) $i, ['testMe'], false, false, $this->tmpDir);
+            $funcs[] = new TestMethod((string) $i, '', ['testMe'], false, false, $this->tmpDir);
         }
 
-        $suite = new Suite('/path', $funcs, false, false, $this->tmpDir);
+        $suite = new Suite('/path', '', $funcs, false, false, $this->tmpDir);
         $this->printer->addTest($suite);
         $this->getStartOutput();
         $numTestsWidth = $this->getObjectValue($this->printer, 'numTestsWidth');
@@ -167,9 +167,9 @@ final class ResultPrinterTest extends ResultTester
 
     public function testAddSuiteAddsFunctionCountToTotalTestCases(): void
     {
-        $suite = new Suite('/path', [
-            new TestMethod('funcOne', ['testMe'], false, false, $this->tmpDir),
-            new TestMethod('funcTwo', ['testMe'], false, false, $this->tmpDir),
+        $suite = new Suite('/path', '', [
+            new TestMethod('funcOne', '', ['testMe'], false, false, $this->tmpDir),
+            new TestMethod('funcTwo', '', ['testMe'], false, false, $this->tmpDir),
         ], false, false, $this->tmpDir);
         $this->printer->addTest($suite);
         static::assertSame(2, $this->printer->getTotalCases());
@@ -177,7 +177,7 @@ final class ResultPrinterTest extends ResultTester
 
     public function testAddTestMethodIncrementsCountByOne(): void
     {
-        $method = new TestMethod('/path', ['testThisMethod'], false, false, $this->tmpDir);
+        $method = new TestMethod('/path', '', ['testThisMethod'], false, false, $this->tmpDir);
         $this->printer->addTest($method);
         static::assertSame(1, $this->printer->getTotalCases());
     }
@@ -548,7 +548,7 @@ final class ResultPrinterTest extends ResultTester
 
     public function testEmptyLogFileRaiseException(): void
     {
-        $test = new ExecutableTestChild(uniqid(), false, false, $this->tmpDir);
+        $test = new ExecutableTestChild(uniqid(), '', false, false, $this->tmpDir);
 
         $this->expectException(RuntimeException::class);
 

--- a/test/Unit/Runners/PHPUnit/RunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/RunnerTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace ParaTest\Tests\Unit\Runners\PHPUnit;
 
+use function array_map;
+use function array_slice;
+use function explode;
+use function implode;
+
 /**
  * @internal
  *
@@ -14,6 +19,17 @@ namespace ParaTest\Tests\Unit\Runners\PHPUnit;
  */
 final class RunnerTest extends RunnerTestCase
 {
+    /**
+     * @param array<class-string> $classes
+     */
+    protected function expectExceptionMessageContainsClasses(array $classes): void
+    {
+        $classes = array_map(static function (string $class): string {
+            return implode('', array_slice(explode('\\', $class), -1));
+        }, $classes);
+        $this->expectExceptionMessageMatches('/' . implode('|', $classes) . '/');
+    }
+
     public function testFunctionalMode(): void
     {
         $this->bareOptions['--path']           = $this->fixture('dataprovider_tests' . DS . 'DataProviderTest.php');

--- a/test/Unit/Runners/PHPUnit/SuiteTest.php
+++ b/test/Unit/Runners/PHPUnit/SuiteTest.php
@@ -20,10 +20,10 @@ final class SuiteTest extends TestBase
     public function testConstructor(): void
     {
         $file        = uniqid('pathToFile_');
-        $testMethod1 = new TestMethod($file, ['testOne', 'testTwo'], false, false, $this->tmpDir);
-        $testMethod2 = new TestMethod($file, ['testThree'], false, false, $this->tmpDir);
+        $testMethod1 = new TestMethod($file, '', ['testOne', 'testTwo'], false, false, $this->tmpDir);
+        $testMethod2 = new TestMethod($file, '', ['testThree'], false, false, $this->tmpDir);
         $testMethods = [$testMethod1, $testMethod2];
-        $suite       = new Suite($file, $testMethods, false, false, $this->tmpDir);
+        $suite       = new Suite($file, '', $testMethods, false, false, $this->tmpDir);
 
         $commandArguments = $suite->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/TestMethodTest.php
+++ b/test/Unit/Runners/PHPUnit/TestMethodTest.php
@@ -19,7 +19,7 @@ final class TestMethodTest extends TestBase
     public function testConstructor(): void
     {
         $file       = uniqid('pathToFile_');
-        $testMethod = new TestMethod($file, ['method1', 'method2'], false, false, $this->tmpDir);
+        $testMethod = new TestMethod($file, '', ['method1', 'method2'], false, false, $this->tmpDir);
 
         $commandArguments = $testMethod->commandArguments(uniqid(), [], null);
 

--- a/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
+++ b/test/Unit/Runners/PHPUnit/WrapperRunnerTest.php
@@ -9,10 +9,13 @@ use ParaTest\Runners\PHPUnit\RunnerInterface;
 use ParaTest\Runners\PHPUnit\WrapperRunner;
 
 use function array_diff;
+use function array_map;
 use function array_unique;
 use function file_get_contents;
+use function implode;
 use function min;
 use function scandir;
+use function sha1;
 use function unlink;
 
 use const FIXTURES;
@@ -32,6 +35,21 @@ final class WrapperRunnerTest extends RunnerTestCase
 
     /** @var class-string<RunnerInterface> */
     protected $runnerClass = WrapperRunner::class;
+
+    /**
+     * Wrapper runner will use a TestSuite wrapper class based on the sha1 hash
+     * of the class name.
+     *
+     * @param array<class-string> $classes
+     */
+    protected function expectExceptionMessageContainsClasses(array $classes): void
+    {
+        $classes = array_map(static function (string $class): string {
+            return 'TestSuite' . sha1($class);
+        }, $classes);
+
+        $this->expectExceptionMessageMatches('/' . implode('|', $classes) . '/');
+    }
 
     public function testWrapperRunnerNotAvailableInFunctionalMode(): void
     {


### PR DESCRIPTION
PHPUnit's TestSuiteLoader will expect to be loading the test class for the very first time, as Paratest uses runs multiple phpunit commands within the same php process, classes may already be loaded.

This happens with tests that reference other test classes i.e. constants, static methods, inheritance etc.
causing paratest to crash :(

By dynamically generating a testsuite class for each class we want to execute, we can avoid these problems giving PHPunit a unique class to load each time.