### PR TITLE
Fix `LogMerger` when no log is created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_PHP_EXEC := docker compose run php
+DOCKER_PHP_EXEC := docker compose run --rm php
 
 SRCS := $(shell find ./src ./test -type f -not -path "*/tmp/*")
 
@@ -62,7 +62,7 @@ code-coverage: coverage/junit.xml
 		--ignore-msi-with-no-mutations \
 		--min-msi=100 \
 		$(INFECTION_ARGS)
-		
+
 .PHONY: clean
 clean:
 	git clean -dfX

--- a/src/JUnit/LogMerger.php
+++ b/src/JUnit/LogMerger.php
@@ -18,7 +18,7 @@ use function ksort;
 final class LogMerger
 {
     /** @param list<SplFileInfo> $junitFiles */
-    public function merge(array $junitFiles): TestSuite
+    public function merge(array $junitFiles): ?TestSuite
     {
         $mainSuite = null;
         foreach ($junitFiles as $junitFile) {
@@ -66,8 +66,6 @@ final class LogMerger
 
             $mainSuite = $this->mergeSuites($mainSuite, $otherSuite);
         }
-
-        assert($mainSuite !== null);
 
         return $mainSuite;
     }

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -344,6 +344,10 @@ final class WrapperRunner implements RunnerInterface
             return;
         }
 
+        if (empty(array_filter(array_map(fn (SplFileInfo $junitFile) => $junitFile->isFile(), $this->junitFiles)))) {
+            return;
+        }
+
         $testSuite = (new LogMerger())->merge($this->junitFiles);
         (new Writer())->write(
             $testSuite,

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -20,6 +20,8 @@ use SplFileInfo;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 
+use function array_filter;
+use function array_map;
 use function array_merge;
 use function array_merge_recursive;
 use function array_shift;
@@ -344,7 +346,7 @@ final class WrapperRunner implements RunnerInterface
             return;
         }
 
-        if (empty(array_filter(array_map(fn (SplFileInfo $junitFile) => $junitFile->isFile(), $this->junitFiles)))) {
+        if (count(array_filter(array_map(static fn (SplFileInfo $junitFile) => $junitFile->isFile(), $this->junitFiles))) === 0) {
             return;
         }
 

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -20,8 +20,6 @@ use SplFileInfo;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 
-use function array_filter;
-use function array_map;
 use function array_merge;
 use function array_merge_recursive;
 use function array_shift;
@@ -346,11 +344,11 @@ final class WrapperRunner implements RunnerInterface
             return;
         }
 
-        if (count(array_filter(array_map(static fn (SplFileInfo $junitFile) => $junitFile->isFile(), $this->junitFiles))) === 0) {
+        $testSuite = (new LogMerger())->merge($this->junitFiles);
+        if ($testSuite === null) {
             return;
         }
 
-        $testSuite = (new LogMerger())->merge($this->junitFiles);
         (new Writer())->write(
             $testSuite,
             $this->options->configuration->logfileJunit(),

--- a/test/Unit/JUnitTest.php
+++ b/test/Unit/JUnitTest.php
@@ -42,6 +42,7 @@ final class JUnitTest extends TestCase
 
         self::assertNotSame([], $junitFiles);
         $testSuite = (new LogMerger())->merge($junitFiles);
+        self::assertNotNull($testSuite);
 
         $outputFile = $tmpDir . '/result.xml';
         (new Writer())->write(
@@ -63,6 +64,7 @@ final class JUnitTest extends TestCase
 
         $junitLog  = FIXTURES . '/special_chars/data-provider-with-special-chars.xml';
         $testSuite = (new LogMerger())->merge([new SplFileInfo($junitLog)]);
+        self::assertNotNull($testSuite);
 
         $outputFile = $tmpDir . '/result.xml';
         (new Writer())->write(

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -280,6 +280,16 @@ final class WrapperRunnerTest extends TestBase
         );
     }
 
+    public function testJunitOutputWithoutTests(): void
+    {
+        $this->bareOptions['path']        = $this->fixture('no_tests');
+        $this->bareOptions['--log-junit'] = $this->tmpDir . DIRECTORY_SEPARATOR . 'test-output.xml';
+        $runnerResult                     = $this->runRunner();
+
+        self::assertStringContainsString('No tests executed!', $runnerResult->output);
+        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
+    }
+
     public function testExitCodesPathWithoutTests(): void
     {
         $this->bareOptions['path'] = $this->fixture('no_tests');

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -286,7 +286,6 @@ final class WrapperRunnerTest extends TestBase
         $this->bareOptions['--log-junit'] = $this->tmpDir . DIRECTORY_SEPARATOR . 'test-output.xml';
         $runnerResult                     = $this->runRunner();
 
-        self::assertStringContainsString('No tests executed!', $runnerResult->output);
         self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 


### PR DESCRIPTION
When thare are no tests to run, the `LogMerger` crashes on the last test (`assert($mainSuite !== null);`), because there are no log files generated to merge together. With this initial check in the WrapperRunner, we only try to merge the log files if there are actually created log files. The list with junitFiles is populated with a SplFileObject for every process/thread it will be running on, but none of the temp files are actually generated/written.