### PR TITLE
Update PHPUnit and add failOnPhpunitDeprecation option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^11.0.6",
         "phpunit/php-file-iterator": "^5.1.0",
         "phpunit/php-timer": "^7.0.1",
-        "phpunit/phpunit": "^11.3.2",
+        "phpunit/phpunit": "^11.3.3",
         "sebastian/environment": "^7.2.0",
         "symfony/console": "^6.4.11 || ^7.1.4",
         "symfony/process": "^6.4.8 || ^7.1.3"

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -294,6 +294,7 @@ final class WrapperRunner implements RunnerInterface
 
         $exitcode = (new ShellExitCodeCalculator())->calculate(
             $this->options->configuration->failOnDeprecation(),
+            $this->options->configuration->failOnPhpunitDeprecation(),
             $this->options->configuration->failOnEmptyTestSuite(),
             $this->options->configuration->failOnIncomplete(),
             $this->options->configuration->failOnNotice(),


### PR DESCRIPTION
**Update PHPUnit to 11.3.3**: This PR updates the PHPUnit version to 11.3.3.

**Synopsis**: The parameters for `PHPUnit\TextUI\ShellExitCodeCalculator::calculate` have changed, including the addition of a boolean `failOnPhpunitDeprecation`.

**Reference**: [PHPUnit commit](https://github.com/sebastianbergmann/phpunit/commit/7266b549ab3d329350b8dec5df8ec6b799da819b#diff-3b9b98e6c9bd5a80fc038c5f5d9b035eff07b727d5d33eb64f93dbc04a1ed409).

**Change**: 
- **Add `failOnPhpunitDeprecation` option**: Introduces a configuration option that causes tests to fail on PHPUnit deprecations, enhancing early detection of deprecated features.
- Added the boolean option in the wrapper.