### PR TITLE
Change `Options` constructor visibility to public

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -87,7 +87,7 @@ final class Options
      * @param non-empty-string                                                      $runner
      * @param non-empty-string                                                      $tmpDir
      */
-    private function __construct(
+    public function __construct(
         public readonly Configuration $configuration,
         public readonly string $phpunit,
         public readonly string $cwd,


### PR DESCRIPTION
I have a custom implementation of the `RunnerInterface` that decorates the default one, and I'd like to be able to modify some options in it.
Currently, it's hard to instantiate a new `Options` object because the constructor is private, so I added a `with` method to help with that. I could also change the visibility of the constructor instead. I'd be ok with either approach, it'd just be nice to be able to do this.