### PR TITLE
Allow `--coverage-filter` to be used multiple times

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -555,7 +555,7 @@ final class Options
             new InputOption(
                 'coverage-filter',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 '@see PHPUnit guide, chapter: ' . $chapter,
             ),
             new InputOption(


### PR DESCRIPTION
In my use case, I specify multiple `coverage-filter` options, and it works fine directly in PHPUnit. When using it parallel via `paratest`, only the last iteration of it is retained, due to how Symfony loads the CLI input, in `symfony/console`: https://github.com/symfony/console/blob/7.1/Input/ArgvInput.php#L259.

ParaTest v7.5.5
PHPUnit 11.3.6
PHP 8.2.24
