### PR TITLE
Require symfony/process ^6.4.14|^7.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^10.5.36",
         "sebastian/environment": "^6.1.0",
         "symfony/console": "^6.4.7 || ^7.1.5",
-        "symfony/process": "^6.4.7 || ^7.1.5"
+        "symfony/process": "^6.4.14 || ^7.1.6"
     },
     "require-dev": {
         "ext-pcov": "*",


### PR DESCRIPTION
symfony/process `<6.4.14` and `<7.1.7` contains CVE-2024-51736 which has been fixed in `6.4.14` and `7.1.7`

https://symfony.com/blog/cve-2024-51736-command-execution-hijack-on-windows-with-process-class