### PR TITLE
Improved regular expression for data-sets when functional flag is used.

### DIFF
--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -29,6 +29,7 @@ use function is_string;
 use function mt_srand;
 use function ob_get_clean;
 use function ob_start;
+use function preg_quote;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -87,7 +88,7 @@ final class SuiteLoader
                 if ($test->providedData() !== []) {
                     $dataName = $test->dataName();
                     if ($this->options->functional) {
-                        $name = sprintf('/%s\s.*%s.*$/', $name, $dataName);
+                        $name = sprintf('/%s%s$/', preg_quote($name, '/'), preg_quote($test->dataSetAsString(), '/'));
                     } else {
                         if (is_int($dataName)) {
                             $name .= '#' . $dataName;

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -631,7 +631,7 @@ EOF;
      * @see https://bugs.php.net/bug.php?id=77726
      * @see https://github.com/php/php-src/pull/8114
      */
-    #[RequiresPhp('8.2')]
+    #[RequiresPhp('>=8.2')]
     public function testFunctionalParallelization(): void
     {
         $this->bareOptions['path']         = $this->fixture('function_parallelization_tests');
@@ -643,7 +643,7 @@ EOF;
 Processes:     2
 Runtime:       PHP %s
 
-..........                                                        10 / 10 (100%)
+....................                                              20 / 20 (100%)
 
 Time: %s, Memory: %s MB
 
@@ -653,7 +653,7 @@ EOF;
         self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 
-    #[RequiresPhp('8.2')]
+    #[RequiresPhp('>=8.2')]
     public function testSameBeginningOfName(): void
     {
         $this->bareOptions['path']         = $this->fixture('same_beginning_of_name');
@@ -675,7 +675,7 @@ EOF;
         self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 
-    #[RequiresPhp('8.2')]
+    #[RequiresPhp('>=8.2')]
     public function testFunctionalParallelizationWithJunitLogging(): void
     {
         $outputFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'test-output.xml';
@@ -692,7 +692,7 @@ EOF;
 Processes:     1
 Runtime:       PHP %s
 
-..........                                                        10 / 10 (100%)
+....................                                              20 / 20 (100%)
 
 Time: %s, Memory: %s MB
 

--- a/test/fixtures/function_parallelization_tests/FunctionalParallelizationTest.php
+++ b/test/fixtures/function_parallelization_tests/FunctionalParallelizationTest.php
@@ -17,6 +17,14 @@ final class FunctionalParallelizationTest extends TestCase
             ['a', 'a'],
             ['b', 'b'],
             ['c', 'c'],
+            ['d', 'd'],
+            ['e', 'e'],
+            ['f', 'f'],
+            ['g', 'g'],
+            ['h', 'h'],
+            ['i', 'i'],
+            ['k', 'k'],
+            ['l', 'l'],
         ];
     }
 
@@ -27,6 +35,7 @@ final class FunctionalParallelizationTest extends TestCase
             'test1 with spaces' => ['a', 'a'],
             "test2 with \0" => ['b', 'b'],
             'test3' => ['c', 'c'],
+            'Test\\Class\\Name' => ['d', 'd'],
         ];
     }
 


### PR DESCRIPTION
Hi, I have problems with the function flag and data providers.

**1st Problem**
I have tests with more than 10 data sets and numeric keys.

The regex as it is generated now does not properly filter the test for the wrapper.

```
"%s\s.*1.*$/" (matches with keys 1, 11, 12, 13, ...)
```

This leads to strange results on the cli.

```
.................... 20 / 20 (100%)
. 21 / 20 (105%)
. 22 / 20 (110%)
. 23 / 20 (114%)
. 24 / 20 (120%)
```

I have fixed it by using dataSetAsString and removed the willdcards from the regex.

**2nd Problem**

Some tests are using the class name as key for the data-provider.

The regex is not properly escaped for class names.
I fixed it using preg_quote.

---

I tried to reflect the problem in the unit test adjustments. Without the SuiteLoader adjustments the tests will fail.

Manually tested only with PHP 8.3.