### PR TITLE
fix: PHPunit extensions must run before data providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,19 +45,19 @@
         "phpunit/php-timer": "^7.0.1",
         "phpunit/phpunit": "^11.5.0",
         "sebastian/environment": "^7.2.0",
-        "symfony/console": "^6.4.14 || ^7.1.7",
-        "symfony/process": "^6.4.14 || ^7.1.7"
+        "symfony/console": "^6.4.14 || ^7.2.0",
+        "symfony/process": "^6.4.14 || ^7.2.0"
     },
     "require-dev": {
         "ext-pcov": "*",
         "ext-posix": "*",
         "doctrine/coding-standard": "^12.0.0",
-        "phpstan/phpstan": "^2",
-        "phpstan/phpstan-deprecation-rules": "^2",
-        "phpstan/phpstan-phpunit": "^2",
+        "phpstan/phpstan": "^2.0.3",
+        "phpstan/phpstan-deprecation-rules": "^2.0.1",
+        "phpstan/phpstan-phpunit": "^2.0.1",
         "phpstan/phpstan-strict-rules": "^2",
         "squizlabs/php_codesniffer": "^3.11.1",
-        "symfony/filesystem": "^6.4.13 || ^7.1.6"
+        "symfony/filesystem": "^6.4.13 || ^7.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -9,7 +9,6 @@ use ParaTest\JUnit\LogMerger;
 use ParaTest\JUnit\Writer;
 use ParaTest\Options;
 use ParaTest\RunnerInterface;
-use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Runner\CodeCoverage;
 use PHPUnit\TestRunner\TestResult\Facade as TestResultFacade;
 use PHPUnit\TestRunner\TestResult\TestResult;
@@ -100,8 +99,6 @@ final class WrapperRunner implements RunnerInterface
         $directory = dirname(__DIR__);
         assert($directory !== '');
         ExcludeList::addDirectory($directory);
-        TestResultFacade::init();
-        EventFacade::instance()->seal();
         $suiteLoader = new SuiteLoader(
             $this->options,
             $this->output,

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -762,21 +762,6 @@ EOF;
         self::assertEquals(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 
-    /**
-     * ###   WARNING   ###
-     *
-     * This test MUST be the last of this file,
-     * otherwise the next one will always fail
-     */
-    public function testProcessIsolation(): void
-    {
-        $this->bareOptions['path']                = $this->fixture('process_isolation' . DIRECTORY_SEPARATOR . 'FooTest.php');
-        $this->bareOptions['--process-isolation'] = true;
-
-        $runnerResult = $this->runRunner();
-        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
-    }
-
     public function testExtensionMustRunBeforeDataProvider(): void
     {
         $this->bareOptions['--configuration'] = $this->fixture('extension_run_before_data_provider' . DIRECTORY_SEPARATOR . 'phpunit.xml');
@@ -796,6 +781,21 @@ OK%a
 EOF;
         self::assertStringMatchesFormat($expectedOutput, $runnerResult->output);
         self::assertEquals(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
+    }
+
+    /**
+     * ###   WARNING   ###
+     *
+     * This test MUST be the last of this file,
+     * otherwise the next one will always fail
+     */
+    public function testProcessIsolation(): void
+    {
+        $this->bareOptions['path']                = $this->fixture('process_isolation' . DIRECTORY_SEPARATOR . 'FooTest.php');
+        $this->bareOptions['--process-isolation'] = true;
+
+        $runnerResult = $this->runRunner();
+        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 
     private static function sorted(string $from): string

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -777,6 +777,27 @@ EOF;
         self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
     }
 
+    public function testExtensionMustRunBeforeDataProvider(): void
+    {
+        $this->bareOptions['--configuration'] = $this->fixture('extension_run_before_data_provider' . DIRECTORY_SEPARATOR . 'phpunit.xml');
+
+        $runnerResult = $this->runRunner();
+
+        $expectedOutput = <<<EOF
+Processes:     %s
+Runtime:       PHP %s
+Configuration: {$this->bareOptions['--configuration']}
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s MB
+
+OK%a
+EOF;
+        self::assertStringMatchesFormat($expectedOutput, $runnerResult->output);
+        self::assertEquals(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
+    }
+
     private static function sorted(string $from): string
     {
         $from = explode(PHP_EOL, $from);

--- a/test/fixtures/extension_run_before_data_provider/ExtensionMustRunBeforeDataProviderTest.php
+++ b/test/fixtures/extension_run_before_data_provider/ExtensionMustRunBeforeDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\extension_run_before_data_provider;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ExtensionMustRunBeforeDataProviderTest extends TestCase
+{
+    public static string $var = 'foo';
+
+    #[DataProvider('provide')]
+    public function testExtensionMustRunBeforeDataProvider(string $var): void
+    {
+        self::assertSame('bar', $var);
+    }
+
+    /** @return iterable<array{string}> */
+    public static function provide(): iterable
+    {
+        if (self::$var !== 'bar') {
+            throw new RuntimeException('Extension did not run before data provider.');
+        }
+
+        yield [self::$var];
+    }
+}

--- a/test/fixtures/extension_run_before_data_provider/PHPUnitExtension.php
+++ b/test/fixtures/extension_run_before_data_provider/PHPUnitExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\extension_run_before_data_provider;
+
+use PHPUnit\Event;
+use PHPUnit\Runner;
+use PHPUnit\TextUI;
+
+final class PHPUnitExtension implements Runner\Extension\Extension
+{
+    public function bootstrap(
+        TextUI\Configuration\Configuration $configuration,
+        Runner\Extension\Facade $facade,
+        Runner\Extension\ParameterCollection $parameters,
+    ): void {
+        $facade->registerSubscribers(
+            new class implements Event\Test\DataProviderMethodCalledSubscriber {
+                public function notify(Event\Test\DataProviderMethodCalled $event): void
+                {
+                    ExtensionMustRunBeforeDataProviderTest::$var = 'bar';
+                }
+            },
+        );
+    }
+}

--- a/test/fixtures/extension_run_before_data_provider/phpunit.xml
+++ b/test/fixtures/extension_run_before_data_provider/phpunit.xml
@@ -1,0 +1,10 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="ExtensionMustRunBeforeDataProviderTest">
+            <file>ExtensionMustRunBeforeDataProviderTest.php</file>
+        </testsuite>
+    </testsuites>
+    <extensions>
+        <bootstrap class="ParaTest\Tests\fixtures\extension_run_before_data_provider\PHPUnitExtension" />
+    </extensions>
+</phpunit>


### PR DESCRIPTION
related to https://github.com/paratestphp/paratest/issues/916