### PR TITLE
Incompatibility between ParaTest 7.3.1 and PHPUnit ^10.5.38 on PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.7",
         "phpunit/php-file-iterator": "^4.1.0",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": "^10.4.2",
+        "phpunit/phpunit": "^10.5.38",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.3.4 || ^7.0.0",
         "symfony/process": "^6.3.4 || ^7.0.0"

--- a/src/JUnit/Writer.php
+++ b/src/JUnit/Writer.php
@@ -23,6 +23,7 @@ use const ENT_XML1;
 /** @internal */
 final class Writer
 {
+    private const TESTSUITES_NAME = 'PHPUnit tests';
     private readonly DOMDocument $document;
 
     public function __construct()
@@ -47,6 +48,7 @@ final class Writer
     {
         $xmlTestsuites = $this->document->createElement('testsuites');
         $xmlTestsuites->appendChild($this->createSuiteNode($testSuite));
+        $xmlTestsuites->setAttribute('name', self::TESTSUITES_NAME);
         $this->document->appendChild($xmlTestsuites);
 
         $xml = $this->document->saveXML();
@@ -58,7 +60,7 @@ final class Writer
     private function createSuiteNode(TestSuite $parentSuite): DOMElement
     {
         $suiteNode = $this->document->createElement('testsuite');
-        $suiteNode->setAttribute('name', $parentSuite->name);
+        $suiteNode->setAttribute('name', $parentSuite->name !== self::TESTSUITES_NAME ? $parentSuite->name : '');
         if ($parentSuite->file !== '') {
             $suiteNode->setAttribute('file', $parentSuite->file);
         }

--- a/src/WrapperRunner/ApplicationForWrapperWorker.php
+++ b/src/WrapperRunner/ApplicationForWrapperWorker.php
@@ -191,7 +191,10 @@ final class ApplicationForWrapperWorker
         }
 
         if (isset($this->testdoxFile)) {
-            $this->testdoxResultCollector = new TestResultCollector(EventFacade::instance());
+            $this->testdoxResultCollector = new TestResultCollector(
+                EventFacade::instance(),
+                $this->configuration->source(),
+            );
         }
 
         TestResultFacade::init();

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -294,6 +294,7 @@ final class WrapperRunner implements RunnerInterface
 
         $exitcode = (new ShellExitCodeCalculator())->calculate(
             $this->options->configuration->failOnDeprecation(),
+            $this->options->configuration->failOnPhpunitDeprecation(),
             $this->options->configuration->failOnEmptyTestSuite(),
             $this->options->configuration->failOnIncomplete(),
             $this->options->configuration->failOnNotice(),

--- a/test/Unit/WrapperRunner/fixtures/common_results_teamcity_output
+++ b/test/Unit/WrapperRunner/fixtures/common_results_teamcity_output
@@ -1,70 +1,35 @@
-
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\ErrorTest' locationHint='php_qn://%s/test/fixtures/common_results/ErrorTest.php::\ParaTest\Tests\fixtures\common_results\ErrorTest' flowId='%d']
-
 ##teamcity[testStarted name='testError' locationHint='php_qn://%s/test/fixtures/common_results/ErrorTest.php::\ParaTest\Tests\fixtures\common_results\ErrorTest::testError' flowId='%d']
-
 ##teamcity[testFailed name='testError' message='RuntimeException: Error here!' details='%s/test/fixtures/common_results/ErrorTest.php:15|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\ErrorTest' flowId='%d']
-
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\FailureTest' locationHint='php_qn://%s/test/fixtures/common_results/FailureTest.php::\ParaTest\Tests\fixtures\common_results\FailureTest' flowId='%d']
-
 ##teamcity[testStarted name='testFailure' locationHint='php_qn://%s/test/fixtures/common_results/FailureTest.php::\ParaTest\Tests\fixtures\common_results\FailureTest::testFailure' flowId='%d']
-
 ##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%s/test/fixtures/common_results/FailureTest.php:14|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\FailureTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\IncompleteTest' locationHint='php_qn://%s/test/fixtures/common_results/IncompleteTest.php::\ParaTest\Tests\fixtures\common_results\IncompleteTest' flowId='%d']
-
 ##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%s/test/fixtures/common_results/IncompleteTest.php::\ParaTest\Tests\fixtures\common_results\IncompleteTest::testIncomplete' flowId='%d']
-
 ##teamcity[testIgnored name='testIncomplete' message='' details='%s/test/fixtures/common_results/IncompleteTest.php:14|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\IncompleteTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\RiskyTest' locationHint='php_qn://%s/test/fixtures/common_results/RiskyTest.php::\ParaTest\Tests\fixtures\common_results\RiskyTest' flowId='%d']
-
 ##teamcity[testStarted name='testRisky' locationHint='php_qn://%s/test/fixtures/common_results/RiskyTest.php::\ParaTest\Tests\fixtures\common_results\RiskyTest::testRisky' flowId='%d']
-
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\RiskyTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\SkippedTest' locationHint='php_qn://%s/test/fixtures/common_results/SkippedTest.php::\ParaTest\Tests\fixtures\common_results\SkippedTest' flowId='%d']
-
 ##teamcity[testStarted name='testSkipped' locationHint='php_qn://%s/test/fixtures/common_results/SkippedTest.php::\ParaTest\Tests\fixtures\common_results\SkippedTest::testSkipped' flowId='%d']
-
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\SkippedTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\SuccessTest' locationHint='php_qn://%s/test/fixtures/common_results/SuccessTest.php::\ParaTest\Tests\fixtures\common_results\SuccessTest' flowId='%d']
-
 ##teamcity[testStarted name='testSuccess' locationHint='php_qn://%s/test/fixtures/common_results/SuccessTest.php::\ParaTest\Tests\fixtures\common_results\SuccessTest::testSuccess' flowId='%d']
-
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\SuccessTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\WarningTest' locationHint='php_qn://%s/test/fixtures/common_results/WarningTest.php::\ParaTest\Tests\fixtures\common_results\WarningTest' flowId='%d']
-
 ##teamcity[testStarted name='testWarning' locationHint='php_qn://%s/test/fixtures/common_results/WarningTest.php::\ParaTest\Tests\fixtures\common_results\WarningTest::testWarning' flowId='%d']
-
 ##teamcity[testFinished name='testWarning' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\WarningTest' flowId='%d']

--- a/test/fixtures/common_results/combined.xml
+++ b/test/fixtures/common_results/combined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="" tests="7" assertions="3" errors="1" failures="1" skipped="2" time="1.234567">
     <testsuite name="ParaTest\Tests\fixtures\common_results\ErrorTest" file="./test/fixtures/common_results/ErrorTest.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="1.234567">
       <testcase name="testError" file="./test/fixtures/common_results/ErrorTest.php" line="13" class="ParaTest\Tests\fixtures\common_results\ErrorTest" classname="ParaTest.Tests.fixtures.common_results.ErrorTest" assertions="0" time="1.234567">

--- a/test/fixtures/common_results/junit/ErrorTest.xml
+++ b/test/fixtures/common_results/junit/ErrorTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\ErrorTest" file="./test/fixtures/common_results/ErrorTest.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="1.234567">
     <testcase name="testError" file="./test/fixtures/common_results/ErrorTest.php" line="13" class="ParaTest\Tests\fixtures\common_results\ErrorTest" classname="ParaTest.Tests.fixtures.common_results.ErrorTest" assertions="0" time="1.234567">
       <error type="RuntimeException">ParaTest\Tests\fixtures\common_results\ErrorTest::testError

--- a/test/fixtures/common_results/junit/FailureTest.xml
+++ b/test/fixtures/common_results/junit/FailureTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\FailureTest" file="./test/fixtures/common_results/FailureTest.php" tests="1" assertions="1" errors="0" failures="1" skipped="0" time="1.234567">
     <testcase name="testFailure" file="./test/fixtures/common_results/FailureTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\FailureTest" classname="ParaTest.Tests.fixtures.common_results.FailureTest" assertions="1" time="1.234567">
       <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\common_results\FailureTest::testFailure

--- a/test/fixtures/common_results/junit/IncompleteTest.xml
+++ b/test/fixtures/common_results/junit/IncompleteTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\IncompleteTest" file="./test/fixtures/common_results/IncompleteTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="1" time="1.234567">
     <testcase name="testIncomplete" file="./test/fixtures/common_results/IncompleteTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\IncompleteTest" classname="ParaTest.Tests.fixtures.common_results.IncompleteTest" assertions="0" time="1.234567">
       <skipped/>

--- a/test/fixtures/common_results/junit/RiskyTest.xml
+++ b/test/fixtures/common_results/junit/RiskyTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\RiskyTest" file="./test/fixtures/common_results/RiskyTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testRisky" file="./test/fixtures/common_results/RiskyTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\RiskyTest" classname="ParaTest.Tests.fixtures.common_results.RiskyTest" assertions="0" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/common_results/junit/SkippedTest.xml
+++ b/test/fixtures/common_results/junit/SkippedTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\SkippedTest" file="./test/fixtures/common_results/SkippedTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="1" time="1.234567">
     <testcase name="testSkipped" file="./test/fixtures/common_results/SkippedTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\SkippedTest" classname="ParaTest.Tests.fixtures.common_results.SkippedTest" assertions="0" time="1.234567">
       <skipped/>

--- a/test/fixtures/common_results/junit/SuccessTest.xml
+++ b/test/fixtures/common_results/junit/SuccessTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\SuccessTest" file="./test/fixtures/common_results/SuccessTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testSuccess" file="./test/fixtures/common_results/SuccessTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\SuccessTest" classname="ParaTest.Tests.fixtures.common_results.SuccessTest" assertions="1" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/common_results/junit/WarningTest.xml
+++ b/test/fixtures/common_results/junit/WarningTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\common_results\WarningTest" file="./test/fixtures/common_results/WarningTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testWarning" file="./test/fixtures/common_results/WarningTest.php" line="16" class="ParaTest\Tests\fixtures\common_results\WarningTest" classname="ParaTest.Tests.fixtures.common_results.WarningTest" assertions="1" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/special_chars/data-provider-with-special-chars.xml
+++ b/test/fixtures/special_chars/data-provider-with-special-chars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" tests="42" assertions="42" errors="0" failures="42" skipped="0" time="1.234567">
     <testsuite name="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse" tests="42" assertions="42" errors="0" failures="42" skipped="0" time="1.234567">
       <testcase name="testIsItFalse with data set #0" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">


### PR DESCRIPTION
🛠️ Environment
| Q  | A   |
|----------|----------|
| ParaTest  | 7.3.1       |
| PHPUnit  | 10.5.38  |
| PHP         | 8.1.30    |


📄 Summary
Starting from PHPUnit 10.5.32, a new flag failOnPhpunitDeprecation was introduced (see [PHPUnit Issue #5937](https://github.com/sebastianbergmann/phpunit/issues/5937)).
This version of PHPUnit is available for PHP 8.1, but ParaTest only added support for this flag for PHP > 8.2.

As a result, the following error occurs when running ParaTest with PHPUnit 10.5.38 on PHP 8.1:
`PHP Fatal error:  Uncaught TypeError: PHPUnit\TextUI\ShellExitCodeCalculator::calculate(): 
Argument #8 ($failOnWarning) must be of type bool, PHPUnit\TestRunner\TestResult\TestResult given, 
called in .../vendor/brianium/paratest/src/WrapperRunner/WrapperRunner.php on line 296 and defined in 
.../vendor/phpunit/phpunit/src/TextUI/ShellExitCodeCalculator.php:25`

If there is anything wrong with the way I structured this pr or if you need more information, please let me know, and I’ll be happy to update it.