### PR TITLE
Emit TestSuitLoaded event

### DIFF
--- a/src/WrapperRunner/ApplicationForWrapperWorker.php
+++ b/src/WrapperRunner/ApplicationForWrapperWorker.php
@@ -95,6 +95,10 @@ final class ApplicationForWrapperWorker
             $testSuite     = TestSuite::fromClassReflector($testSuiteRefl);
         }
 
+        EventFacade::emitter()->testSuiteLoaded(
+            TestSuiteBuilder::from($testSuite),
+        );
+
         (new TestSuiteFilterProcessor())->process($this->configuration, $testSuite);
 
         if ($filter !== null) {


### PR DESCRIPTION
Currently extensions that rely on the TestSuitLoaded event, like the [`SymfonyExtension`](https://github.com/symfony/symfony/blob/d824d5362af59a9f697dcb368786b684987b2a03/src/Symfony/Bridge/PhpUnit/SymfonyExtension.php), might not work because the event is never dispatched in the child processes.

One example is the [`RegisterClockMockSubscriber`](https://github.com/symfony/symfony/blob/d824d5362af59a9f697dcb368786b684987b2a03/src/Symfony/Bridge/PhpUnit/Extension/RegisterClockMockSubscriber.php), which checks whether a test belongs to a certain group and registers the class to use mocked time.