### PR TITLE
Fix Incompatibilty With PhpStorm on Windows

### DIFF
--- a/src/Util/PhpstormHelper.php
+++ b/src/Util/PhpstormHelper.php
@@ -10,6 +10,7 @@ use function array_search;
 use function array_unshift;
 use function in_array;
 use function str_ends_with;
+use function str_replace;
 
 /** @internal */
 final readonly class PhpstormHelper
@@ -48,7 +49,7 @@ final readonly class PhpstormHelper
     /** @param  array<int, string> $argv */
     private static function getArgvKeyFor(array $argv, string $searchFor): int
     {
-        $searchForForwardSlash = str_replace('\\', '/', $searchFor);
+        $searchForForwardSlash  = str_replace('\\', '/', $searchFor);
         $searchForBackwardSlash = str_replace('/', '\\', $searchFor);
 
         foreach ($argv as $key => $arg) {

--- a/src/Util/PhpstormHelper.php
+++ b/src/Util/PhpstormHelper.php
@@ -48,8 +48,11 @@ final readonly class PhpstormHelper
     /** @param  array<int, string> $argv */
     private static function getArgvKeyFor(array $argv, string $searchFor): int
     {
+        $searchForForwardSlash = str_replace('\\', '/', $searchFor);
+        $searchForBackwardSlash = str_replace('/', '\\', $searchFor);
+
         foreach ($argv as $key => $arg) {
-            if (str_ends_with($arg, $searchFor)) {
+            if (str_ends_with($arg, $searchForForwardSlash) || str_ends_with($arg, $searchForBackwardSlash)) {
                 return $key;
             }
         }


### PR DESCRIPTION
This is a bug fix for the following error:
```sh
Fatal error: Uncaught RuntimeException
Missing path to '/paratest_for_phpstorm' in C:\repos\some_repo\vendor\brianium\paratest\src\Util\PhpstormHelper.php:60
```

## Detailed Description
This error occurred when trying to use the "Rerun Failed Test" functionality in PhpStorm on a Windows machine. This only happened if the run configuration option "Use ParaTest" is set by the user and contains backward slashes. On Windows this is very common, since the native Windows Explorer "Select Path" dialog can be used.

<img width="1662" height="160" alt="grafik" src="https://github.com/user-attachments/assets/31d35637-9fa2-4581-a230-5ebab1ae64f9" />


## Root Cause
When this option is set, the resulting command line contains mixed forward and backward slashes, because PhpStorm inserts the path as is:
```sh
C:\php\php.exe C:\repos\some_project\vendor\bin\paratest_for_phpstorm C:/repos/some_project/vendor/phpunit/phpunit/phpunit --configuration C:\repos\some_project\phpunit.xml --filter "..." C:\xampp\htdocs\bidX\tests\Unit --teamcity
```

Therefore, calling
```php
self::getArgvKeyFor($argv, '/paratest_for_phpstorm')
```
throws the previously mentioned error, because it tries to find the `paratest_for_phpstorm` binary prefixed with a forward slash.

## The Fix
Search for both `/paratest_for_phpstorm` and `\paratest_for_phpstorm` in the provided arguments.

## References
This PR relates to these issues:
- #692
- #695

