### PR TITLE
Fix JUnit log merging in `--functional` mode

### DIFF
--- a/src/JUnit/LogMerger.php
+++ b/src/JUnit/LogMerger.php
@@ -64,42 +64,9 @@ final readonly class LogMerger
                 }
             }
 
-            $mainSuite = $this->mergeSuites($mainSuite, $otherSuite);
+            $mainSuite = $mainSuite->mergeWith($otherSuite);
         }
 
         return $mainSuite;
-    }
-
-    private function mergeSuites(TestSuite $suite1, TestSuite $suite2): TestSuite
-    {
-        assert($suite1->name === $suite2->name);
-
-        $suites = $suite1->suites;
-        foreach ($suite2->suites as $suite2suiteName => $suite2suite) {
-            if (! isset($suites[$suite2suiteName])) {
-                $suites[$suite2suiteName] = $suite2suite;
-                continue;
-            }
-
-            $suites[$suite2suiteName] = $this->mergeSuites(
-                $suites[$suite2suiteName],
-                $suite2suite,
-            );
-        }
-
-        ksort($suites);
-
-        return new TestSuite(
-            $suite1->name,
-            $suite1->tests + $suite2->tests,
-            $suite1->assertions + $suite2->assertions,
-            $suite1->failures + $suite2->failures,
-            $suite1->errors + $suite2->errors,
-            $suite1->skipped + $suite2->skipped,
-            $suite1->time + $suite2->time,
-            $suite1->file,
-            $suites,
-            array_merge($suite1->cases, $suite2->cases),
-        );
     }
 }

--- a/src/JUnit/LogMerger.php
+++ b/src/JUnit/LogMerger.php
@@ -6,10 +6,6 @@ namespace ParaTest\JUnit;
 
 use SplFileInfo;
 
-use function array_merge;
-use function assert;
-use function ksort;
-
 /**
  * @internal
  *

--- a/src/JUnit/TestSuite.php
+++ b/src/JUnit/TestSuite.php
@@ -75,7 +75,11 @@ final readonly class TestSuite
                 return $testSuite;
             }
 
-            $suites[$testSuite->name] = $testSuite;
+            if (isset($suites[$testSuite->name])) {
+                $suites[$testSuite->name] = $suites[$testSuite->name]->mergeWith($testSuite);
+            } else {
+                $suites[$testSuite->name] = $testSuite;
+            }
 
             if (! $isRootSuite) {
                 continue;
@@ -107,4 +111,33 @@ final readonly class TestSuite
             $cases,
         );
     }
+    
+    public function mergeWith(self $other): self {
+        assert($this->name === $other->name);
+
+        $suites = $this->suites;
+        foreach ($other->suites as $otherSuiteName => $otherSuite) {
+            if (! isset($this->suites[$otherSuiteName])) {
+                $suites[$otherSuiteName] = $otherSuite;
+                continue;
+            }
+
+            $suites[$otherSuiteName]->mergeWith($otherSuite);
+        }
+
+        ksort($suites);
+
+        return new TestSuite(
+            $this->name,
+            $this->tests + $other->tests,
+            $this->assertions + $other->assertions,
+            $this->failures + $other->failures,
+            $this->errors + $other->errors,
+            $this->skipped + $other->skipped,
+            $this->time + $other->time,
+            $this->file,
+            $suites,
+            array_merge($this->cases, $other->cases),
+        );
+    } 
 }

--- a/src/JUnit/TestSuite.php
+++ b/src/JUnit/TestSuite.php
@@ -7,9 +7,11 @@ namespace ParaTest\JUnit;
 use SimpleXMLElement;
 use SplFileInfo;
 
+use function array_merge;
 use function assert;
 use function count;
 use function file_get_contents;
+use function ksort;
 
 /**
  * @internal
@@ -111,8 +113,9 @@ final readonly class TestSuite
             $cases,
         );
     }
-    
-    public function mergeWith(self $other): self {
+
+    public function mergeWith(self $other): self
+    {
         assert($this->name === $other->name);
 
         $suites = $this->suites;
@@ -139,5 +142,5 @@ final readonly class TestSuite
             $suites,
             array_merge($this->cases, $other->cases),
         );
-    } 
+    }
 }

--- a/test/Unit/JUnitTest.php
+++ b/test/Unit/JUnitTest.php
@@ -72,4 +72,15 @@ final class JUnitTest extends TestCase
 
         self::assertXmlFileEqualsXmlFile($junitLog, $outputFile);
     }
+
+    public function testLoadTestSuiteContainingMultipleSuitesWithSameName(): void
+    {
+        $junitProcessLog  = FIXTURES . '/github/GH997/worker_tmp_junit.xml';
+        $testSuite = TestSuite::fromFile(new SplFileInfo($junitProcessLog));
+
+        self::assertCount(1, $testSuite->suites);
+        self::assertArrayHasKey('ParaTest\Tests\fixtures\github\GH997\SuccessfulTests', $testSuite->suites);
+        self::assertCount(2, $testSuite->suites['ParaTest\Tests\fixtures\github\GH997\SuccessfulTests']->cases);
+        self::assertEquals(2, $testSuite->suites['ParaTest\Tests\fixtures\github\GH997\SuccessfulTests']->tests);
+    }
 }

--- a/test/Unit/JUnitTest.php
+++ b/test/Unit/JUnitTest.php
@@ -75,8 +75,8 @@ final class JUnitTest extends TestCase
 
     public function testLoadTestSuiteContainingMultipleSuitesWithSameName(): void
     {
-        $junitProcessLog  = FIXTURES . '/github/GH997/worker_tmp_junit.xml';
-        $testSuite = TestSuite::fromFile(new SplFileInfo($junitProcessLog));
+        $junitProcessLog = FIXTURES . '/github/GH997/worker_tmp_junit.xml';
+        $testSuite       = TestSuite::fromFile(new SplFileInfo($junitProcessLog));
 
         self::assertCount(1, $testSuite->suites);
         self::assertArrayHasKey('ParaTest\Tests\fixtures\github\GH997\SuccessfulTests', $testSuite->suites);

--- a/test/fixtures/github/GH997/SuccessfulTests.php
+++ b/test/fixtures/github/GH997/SuccessfulTests.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\github\GH997;
+
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class SuccessfulTests extends TestCase
+{
+    public function testSuccessOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testSuccessTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/fixtures/github/GH997/phpunit.xml
+++ b/test/fixtures/github/GH997/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="Github issue GH997">
+            <file>SuccessfulTests.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/fixtures/github/GH997/worker_tmp_junit.xml
+++ b/test/fixtures/github/GH997/worker_tmp_junit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.003250">
+        <testcase name="testSuccessOne" file="test/fixtures/github/GH997/SuccessfulTests.php" line="12" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="0.003250"/>
+    </testsuite>
+    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.001141">
+        <testcase name="testSuccessTwo" file="test/fixtures/github/GH997/SuccessfulTests.php" line="17" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="0.001141"/>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
I also moved `mergeWith `from `LogMerger `to `TestSuite `to avoid duplicate code