### PR TITLE
add support for phpunit --only-summary-for-coverage-text option

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -575,6 +575,13 @@ final readonly class Options
                 false,
             ),
             new InputOption(
+                'only-summary-for-coverage-text',
+                null,
+                InputOption::VALUE_NONE,
+                '@see PHPUnit guide, chapter: ' . $chapter,
+                null,
+            ),
+            new InputOption(
                 'coverage-xml',
                 null,
                 InputOption::VALUE_REQUIRED,


### PR DESCRIPTION
thats a simple change which we use as a custom composer patch for quite some time now :)

fixes #986