### PR TITLE
remove --debug mention on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ public function setUp(): void
 ## Troubleshooting
 
 If you run into problems with `paratest`, try to get more information about the issue by enabling debug output via
-`--verbose --debug`.
+`--verbose`.
 
 When a sub-process fails, the originating command is given in the output and can then be copy-pasted in the terminal
 to be run and debugged. All internal commands run with `--printer [...]\NullPhpunitPrinter` which silence the original


### PR DESCRIPTION
the `--debug` option does not exist currently, lets remove that from the documentation.