### PR TITLE
feat: add `--shard` option

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -6,6 +6,7 @@ namespace ParaTest;
 
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
+use InvalidArgumentException;
 use PHPUnit\TextUI\Configuration\Builder;
 use PHPUnit\TextUI\Configuration\Configuration;
 use RuntimeException;
@@ -28,6 +29,7 @@ use function is_array;
 use function is_bool;
 use function is_numeric;
 use function is_string;
+use function preg_match;
 use function realpath;
 use function sprintf;
 use function str_starts_with;
@@ -103,6 +105,8 @@ final readonly class Options
         public string $tmpDir,
         public bool $verbose,
         public bool $functional,
+        public int $currentShard,
+        public int $totalShards,
     ) {
         $this->needsTeamcity = $configuration->outputIsTeamCity() || $configuration->hasLogfileTeamcity();
     }
@@ -157,6 +161,22 @@ final readonly class Options
             $options['coverage-text'] = 'php://stdout';
         }
 
+        assert(is_string($options['shards'] ?? ''));
+        $parts        = [];
+        $currentShard = $totalShards = 0;
+        $pregMatch    = preg_match('/^([0-9]+)\/([0-9]+)$/', $options['shards'] ?? '', $parts);
+        if ($pregMatch === 1) {
+            $currentShard = (int) $parts[1];
+            $totalShards  = (int) $parts[2];
+
+            // Validate shard parameters - if invalid, throw an exception
+            if ($totalShards < $currentShard || $totalShards <= 0 || $currentShard <= 0) {
+                throw new InvalidArgumentException('Invalid shards parameter.');
+            }
+        }
+
+        unset($options['shards']);
+
         // Must be a static non-customizable reference because ParaTest code
         // is strictly coupled with PHPUnit pinned version
         $phpunit = self::getPhpunitBinary();
@@ -208,6 +228,8 @@ final readonly class Options
             $tmpDir,
             $verbose,
             $functional,
+            $currentShard,
+            $totalShards,
         );
     }
 
@@ -274,6 +296,12 @@ final readonly class Options
                 'v',
                 InputOption::VALUE_NONE,
                 'Output more verbose information',
+            ),
+            new InputOption(
+                'shards',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                '<current>/<total> Run a specific part of the suite',
             ),
 
             // PHPUnit options
@@ -667,5 +695,10 @@ final readonly class Options
         }
 
         return $env;
+    }
+
+    public function hasShards(): bool
+    {
+        return $this->currentShard > 0 && $this->totalShards > 0;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -82,7 +82,7 @@ final readonly class Options
         'default-time-limit' => true,
     ];
 
-    public readonly bool $needsTeamcity;
+    public bool $needsTeamcity;
 
     /**
      * @param non-empty-string                                                      $phpunit
@@ -161,21 +161,30 @@ final readonly class Options
             $options['coverage-text'] = 'php://stdout';
         }
 
-        assert(is_string($options['shards'] ?? ''));
-        $parts        = [];
+        $shard = $options['shard'];
+        unset($options['shard']);
         $currentShard = $totalShards = 0;
-        $pregMatch    = preg_match('/^([0-9]+)\/([0-9]+)$/', $options['shards'] ?? '', $parts);
-        if ($pregMatch === 1) {
-            $currentShard = (int) $parts[1];
-            $totalShards  = (int) $parts[2];
+        if (is_string($shard)) {
+            $parts     = [];
+            $pregMatch = preg_match('/^(?<current>\d+)\/(?<total>\d+)$/', $shard, $parts);
+            if ($pregMatch !== 1) {
+                throw new InvalidArgumentException('Invalid shard parameter format: ' . $shard);
+            }
 
-            // Validate shard parameters - if invalid, throw an exception
-            if ($totalShards < $currentShard || $totalShards <= 0 || $currentShard <= 0) {
-                throw new InvalidArgumentException('Invalid shards parameter.');
+            $currentShard = (int) $parts['current'];
+            $totalShards  = (int) $parts['total'];
+            if ($currentShard <= 0) {
+                throw new InvalidArgumentException('Current shard must be a positive integer: ' . $shard);
+            }
+
+            if ($totalShards <= 1) {
+                throw new InvalidArgumentException('Total shards must be an integer greater than 1: ' . $shard);
+            }
+
+            if ($currentShard > $totalShards) {
+                throw new InvalidArgumentException('Current shard must be less or equal to total shards: ' . $shard);
             }
         }
-
-        unset($options['shards']);
 
         // Must be a static non-customizable reference because ParaTest code
         // is strictly coupled with PHPUnit pinned version
@@ -298,7 +307,7 @@ final readonly class Options
                 'Output more verbose information',
             ),
             new InputOption(
-                'shards',
+                'shard',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 '<current>/<total> Run a specific part of the suite',
@@ -697,7 +706,7 @@ final readonly class Options
         return $env;
     }
 
-    public function hasShards(): bool
+    public function hasShard(): bool
     {
         return $this->currentShard > 0 && $this->totalShards > 0;
     }

--- a/src/WrapperRunner/ResultPrinter.php
+++ b/src/WrapperRunner/ResultPrinter.php
@@ -103,8 +103,8 @@ final class ResultPrinter
         // @see \PHPUnit\TextUI\Application::writeRuntimeInformation()
         $write('Processes', (string) $this->options->processes);
 
-        if ($this->options->hasShards()) {
-            $write('Shards', $this->options->currentShard . '/' . $this->options->totalShards);
+        if ($this->options->hasShard()) {
+            $write('Shard', $this->options->currentShard . '/' . $this->options->totalShards);
         }
 
         $runtime = 'PHP ' . PHP_VERSION;

--- a/src/WrapperRunner/ResultPrinter.php
+++ b/src/WrapperRunner/ResultPrinter.php
@@ -103,6 +103,10 @@ final class ResultPrinter
         // @see \PHPUnit\TextUI\Application::writeRuntimeInformation()
         $write('Processes', (string) $this->options->processes);
 
+        if ($this->options->hasShards()) {
+            $write('Shards', $this->options->currentShard . '/' . $this->options->totalShards);
+        }
+
         $runtime = 'PHP ' . PHP_VERSION;
 
         if ($this->options->configuration->hasCoverageReport()) {

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -7,6 +7,7 @@ namespace ParaTest\WrapperRunner;
 use Generator;
 use ParaTest\Options;
 use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\Extension\ExtensionBootstrapper;
@@ -28,7 +29,10 @@ use ReflectionProperty;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_keys;
+use function array_merge;
+use function array_slice;
 use function assert;
+use function ceil;
 use function count;
 use function is_int;
 use function is_string;
@@ -86,6 +90,10 @@ final readonly class SuiteLoader
         EventFacade::instance()->seal();
 
         $testSuite = (new TestSuiteBuilder())->build($this->options->configuration);
+
+        if ($this->options->hasShards()) {
+            $testSuite = $this->shardTests($testSuite);
+        }
 
         if ($this->options->configuration->executionOrder() === TestSuiteSorter::ORDER_RANDOMIZED) {
             mt_srand($this->options->configuration->randomOrderSeed());
@@ -213,5 +221,38 @@ final readonly class SuiteLoader
         assert($substr !== '');
 
         return $substr;
+    }
+
+    private function shardTests(TestSuite $suite): TestSuite
+    {
+        $tests = $this->extractTestsInSuite($suite);
+
+        $shards        = $this->options->totalShards;
+        $current       = $this->options->currentShard - 1; // 0 indexed. Shard 1 is in reality shard 0
+        $total         = count($tests);
+        $testsPerShard = (int) ceil($total / $shards);
+        $offset        = $testsPerShard * $current;
+
+        $testSuite = (new TestSuiteBuilder())->build($this->options->configuration);
+        $testSuite->setTests(array_slice($tests, $offset, $testsPerShard));
+
+        return $testSuite;
+    }
+
+    /** @return list<Test> */
+    private function extractTestsInSuite(TestSuite $suite): array
+    {
+        $extractedTests = [];
+        $suiteItems     = $suite->tests();
+
+        foreach ($suiteItems as $item) {
+            if ($item instanceof TestSuite) {
+                $extractedTests = array_merge($extractedTests, $this->extractTestsInSuite($item));
+            } else {
+                $extractedTests[] = $item;
+            }
+        }
+
+        return $extractedTests;
     }
 }

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -91,8 +91,8 @@ final readonly class SuiteLoader
 
         $testSuite = (new TestSuiteBuilder())->build($this->options->configuration);
 
-        if ($this->options->hasShards()) {
-            $testSuite = $this->shardTests($testSuite);
+        if ($this->options->hasShard()) {
+            $this->shardTests($testSuite);
         }
 
         if ($this->options->configuration->executionOrder() === TestSuiteSorter::ORDER_RANDOMIZED) {
@@ -223,7 +223,7 @@ final readonly class SuiteLoader
         return $substr;
     }
 
-    private function shardTests(TestSuite $suite): TestSuite
+    private function shardTests(TestSuite $suite): void
     {
         $tests = $this->extractTestsInSuite($suite);
 
@@ -233,10 +233,7 @@ final readonly class SuiteLoader
         $testsPerShard = (int) ceil($total / $shards);
         $offset        = $testsPerShard * $current;
 
-        $testSuite = (new TestSuiteBuilder())->build($this->options->configuration);
-        $testSuite->setTests(array_slice($tests, $offset, $testsPerShard));
-
-        return $testSuite;
+        $suite->setTests(array_slice($tests, $offset, $testsPerShard));
     }
 
     /** @return list<Test> */

--- a/test/Unit/OptionsTest.php
+++ b/test/Unit/OptionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ParaTest\Tests\Unit;
 
+use InvalidArgumentException;
 use ParaTest\Options;
 use ParaTest\Tests\TestBase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -131,5 +132,84 @@ final class OptionsTest extends TestBase
         $options = $this->createOptionsFromArgv(['--log-teamcity' => 'LOG-TEAMCITY'], __DIR__);
 
         self::assertTrue($options->needsTeamcity);
+    }
+
+    public function testShardOptionsDefaultValues(): void
+    {
+        $options = $this->createOptionsFromArgv([], __DIR__);
+
+        self::assertSame(0, $options->currentShard);
+        self::assertSame(0, $options->totalShards);
+        self::assertFalse($options->hasShards());
+    }
+
+    public function testValidShardOption(): void
+    {
+        $options = $this->createOptionsFromArgv(['--shards' => '2/5'], __DIR__);
+
+        self::assertSame(2, $options->currentShard);
+        self::assertSame(5, $options->totalShards);
+        self::assertTrue($options->hasShards());
+    }
+
+    public function testValidShardOptionSingleDigit(): void
+    {
+        $options = $this->createOptionsFromArgv(['--shards' => '1/1'], __DIR__);
+
+        self::assertSame(1, $options->currentShard);
+        self::assertSame(1, $options->totalShards);
+        self::assertTrue($options->hasShards());
+    }
+
+    public function testValidShardOptionLargeNumbers(): void
+    {
+        $options = $this->createOptionsFromArgv(['--shards' => '42/100'], __DIR__);
+
+        self::assertSame(42, $options->currentShard);
+        self::assertSame(100, $options->totalShards);
+        self::assertTrue($options->hasShards());
+    }
+
+    public function testInvalidShardOptionFormats(): void
+    {
+        // Test various invalid formats that don't match the regex pattern - they should result in no sharding
+        $invalidFormatsNoException = [
+            'invalid',
+            '1',
+            '1/',
+            '/5',
+            '1/5/extra',
+            'a/b',
+        ];
+
+        foreach ($invalidFormatsNoException as $format) {
+            $options = $this->createOptionsFromArgv(['--shards' => $format], __DIR__);
+
+            self::assertSame(0, $options->currentShard, "Failed for format: $format");
+            self::assertSame(0, $options->totalShards, "Failed for format: $format");
+            self::assertFalse($options->hasShards(), "Failed for format: $format");
+        }
+
+        // Test formats that match regex but have invalid values - they should throw exceptions
+        $invalidFormatsWithException = [
+            '1/0',  // total shards cannot be 0
+            '0/5',  // current shard cannot be 0
+            '6/5',  // current shard cannot be greater than total
+        ];
+
+        foreach ($invalidFormatsWithException as $format) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('Invalid shards parameter.');
+            $this->createOptionsFromArgv(['--shards' => $format], __DIR__);
+        }
+    }
+
+    public function testShardOptionNotProvided(): void
+    {
+        $options = $this->createOptionsFromArgv(['--verbose' => true], __DIR__);
+
+        self::assertSame(0, $options->currentShard);
+        self::assertSame(0, $options->totalShards);
+        self::assertFalse($options->hasShards());
     }
 }

--- a/test/Unit/OptionsTest.php
+++ b/test/Unit/OptionsTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use ParaTest\Options;
 use ParaTest\Tests\TestBase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function mt_rand;
 use function uniqid;
@@ -140,68 +141,50 @@ final class OptionsTest extends TestBase
 
         self::assertSame(0, $options->currentShard);
         self::assertSame(0, $options->totalShards);
-        self::assertFalse($options->hasShards());
+        self::assertFalse($options->hasShard());
     }
 
     public function testValidShardOption(): void
     {
-        $options = $this->createOptionsFromArgv(['--shards' => '2/5'], __DIR__);
+        $options = $this->createOptionsFromArgv(['--shard' => '2/5'], __DIR__);
 
         self::assertSame(2, $options->currentShard);
         self::assertSame(5, $options->totalShards);
-        self::assertTrue($options->hasShards());
-    }
-
-    public function testValidShardOptionSingleDigit(): void
-    {
-        $options = $this->createOptionsFromArgv(['--shards' => '1/1'], __DIR__);
-
-        self::assertSame(1, $options->currentShard);
-        self::assertSame(1, $options->totalShards);
-        self::assertTrue($options->hasShards());
+        self::assertTrue($options->hasShard());
     }
 
     public function testValidShardOptionLargeNumbers(): void
     {
-        $options = $this->createOptionsFromArgv(['--shards' => '42/100'], __DIR__);
+        $options = $this->createOptionsFromArgv(['--shard' => '42/100'], __DIR__);
 
         self::assertSame(42, $options->currentShard);
         self::assertSame(100, $options->totalShards);
-        self::assertTrue($options->hasShards());
+        self::assertTrue($options->hasShard());
     }
 
-    public function testInvalidShardOptionFormats(): void
+    #[DataProvider('provideInvalidShardOptionFormats')]
+    public function testInvalidShardOptionFormats(string $shard): void
     {
-        // Test various invalid formats that don't match the regex pattern - they should result in no sharding
-        $invalidFormatsNoException = [
-            'invalid',
-            '1',
-            '1/',
-            '/5',
-            '1/5/extra',
-            'a/b',
-        ];
+        self::assertNotEmpty($shard);
+        $this->expectException(InvalidArgumentException::class);
 
-        foreach ($invalidFormatsNoException as $format) {
-            $options = $this->createOptionsFromArgv(['--shards' => $format], __DIR__);
+        $this->createOptionsFromArgv(['--shard' => $shard], __DIR__);
+    }
 
-            self::assertSame(0, $options->currentShard, "Failed for format: $format");
-            self::assertSame(0, $options->totalShards, "Failed for format: $format");
-            self::assertFalse($options->hasShards(), "Failed for format: $format");
-        }
-
-        // Test formats that match regex but have invalid values - they should throw exceptions
-        $invalidFormatsWithException = [
-            '1/0',  // total shards cannot be 0
-            '0/5',  // current shard cannot be 0
-            '6/5',  // current shard cannot be greater than total
-        ];
-
-        foreach ($invalidFormatsWithException as $format) {
-            $this->expectException(InvalidArgumentException::class);
-            $this->expectExceptionMessage('Invalid shards parameter.');
-            $this->createOptionsFromArgv(['--shards' => $format], __DIR__);
-        }
+    /** @return iterable<list<non-empty-string>> */
+    public static function provideInvalidShardOptionFormats(): iterable
+    {
+        yield ['invalid'];
+        yield ['1'];
+        yield ['1/'];
+        yield ['/5'];
+        yield ['1/5/extra'];
+        yield ['a/b'];
+        yield ['1/0'];
+        yield ['0/1'];
+        yield ['0/0'];
+        yield ['6/5'];
+        yield ['1/1'];
     }
 
     public function testShardOptionNotProvided(): void
@@ -210,6 +193,6 @@ final class OptionsTest extends TestBase
 
         self::assertSame(0, $options->currentShard);
         self::assertSame(0, $options->totalShards);
-        self::assertFalse($options->hasShards());
+        self::assertFalse($options->hasShard());
     }
 }

--- a/test/Unit/WrapperRunner/ResultPrinterTest.php
+++ b/test/Unit/WrapperRunner/ResultPrinterTest.php
@@ -121,12 +121,12 @@ final class ResultPrinterTest extends TestBase
     public function testStartPrintsShardInfo(): void
     {
         $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv([
-            '--shards' => '3/5',
+            '--shard' => '3/5',
             '--verbose' => true,
         ]));
         $contents      = $this->getStartOutput();
 
-        self::assertStringContainsString("Shards:        3/5\n", $contents);
+        self::assertStringContainsString("Shard:         3/5\n", $contents);
     }
 
     public function testStartDoesNotPrintShardInfoWhenNotConfigured(): void
@@ -134,18 +134,7 @@ final class ResultPrinterTest extends TestBase
         $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv(['--verbose' => true]));
         $contents      = $this->getStartOutput();
 
-        self::assertStringNotContainsString('Shards:', $contents);
-    }
-
-    public function testStartDoesNotPrintShardInfoForInvalidShards(): void
-    {
-        $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv([
-            '--shards' => 'invalid',
-            '--verbose' => true,
-        ]));
-        $contents      = $this->getStartOutput();
-
-        self::assertStringNotContainsString('Shards:', $contents);
+        self::assertStringNotContainsString('Shard:', $contents);
     }
 
     public function testGetHeader(): void

--- a/test/Unit/WrapperRunner/ResultPrinterTest.php
+++ b/test/Unit/WrapperRunner/ResultPrinterTest.php
@@ -118,6 +118,36 @@ final class ResultPrinterTest extends TestBase
         self::assertStringStartsWith("Processes:     1\n", $contents);
     }
 
+    public function testStartPrintsShardInfo(): void
+    {
+        $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv([
+            '--shards' => '3/5',
+            '--verbose' => true,
+        ]));
+        $contents      = $this->getStartOutput();
+
+        self::assertStringContainsString("Shards:        3/5\n", $contents);
+    }
+
+    public function testStartDoesNotPrintShardInfoWhenNotConfigured(): void
+    {
+        $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv(['--verbose' => true]));
+        $contents      = $this->getStartOutput();
+
+        self::assertStringNotContainsString('Shards:', $contents);
+    }
+
+    public function testStartDoesNotPrintShardInfoForInvalidShards(): void
+    {
+        $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv([
+            '--shards' => 'invalid',
+            '--verbose' => true,
+        ]));
+        $contents      = $this->getStartOutput();
+
+        self::assertStringNotContainsString('Shards:', $contents);
+    }
+
     public function testGetHeader(): void
     {
         $this->printer->printResults($this->getEmptyTestResult(), [], []);

--- a/test/Unit/WrapperRunner/SuiteLoaderTest.php
+++ b/test/Unit/WrapperRunner/SuiteLoaderTest.php
@@ -70,7 +70,7 @@ final class SuiteLoaderTest extends TestBase
 
     public function testShardTestsWithValidShards(): void
     {
-        $this->bareOptions['--shards']        = '2/3';
+        $this->bareOptions['--shard']         = '2/3';
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
 
         $loader = $this->loadSuite();
@@ -84,21 +84,9 @@ final class SuiteLoaderTest extends TestBase
         self::assertCount($loader->testCount, $loader->tests);
     }
 
-    public function testShardTestsWithSingleShard(): void
-    {
-        $this->bareOptions['--shards']        = '1/1';
-        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-
-        $loader = $this->loadSuite();
-
-        // With 1 shard, all tests should be included
-        self::assertSame(7, $loader->testCount);
-        self::assertCount(7, $loader->tests);
-    }
-
     public function testShardTestsWithFirstShard(): void
     {
-        $this->bareOptions['--shards']        = '1/5';
+        $this->bareOptions['--shard']         = '1/5';
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
 
         $loader = $this->loadSuite();
@@ -112,7 +100,7 @@ final class SuiteLoaderTest extends TestBase
 
     public function testShardTestsWithLastShard(): void
     {
-        $this->bareOptions['--shards']        = '5/5';
+        $this->bareOptions['--shard']         = '5/5';
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
 
         $loader = $this->loadSuite();
@@ -133,18 +121,6 @@ final class SuiteLoaderTest extends TestBase
         $loader = $this->loadSuite();
 
         // Without shards, all tests should be loaded
-        self::assertSame(7, $loader->testCount);
-        self::assertCount(7, $loader->tests);
-    }
-
-    public function testShardTestsWithInvalidShard(): void
-    {
-        $this->bareOptions['--shards']        = 'invalid';
-        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-
-        $loader = $this->loadSuite();
-
-        // Invalid shard format should not apply sharding, load all tests
         self::assertSame(7, $loader->testCount);
         self::assertCount(7, $loader->tests);
     }

--- a/test/Unit/WrapperRunner/SuiteLoaderTest.php
+++ b/test/Unit/WrapperRunner/SuiteLoaderTest.php
@@ -68,6 +68,87 @@ final class SuiteLoaderTest extends TestBase
         self::assertStringContainsString('my_test.phpt', $file);
     }
 
+    public function testShardTestsWithValidShards(): void
+    {
+        $this->bareOptions['--shards']        = '2/3';
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // With 7 tests total and 3 shards, shard 2 should get tests at positions 3,4,5 (0-indexed: 2,3,4)
+        // Tests per shard: ceil(7/3) = 3
+        // Shard 1 (0-indexed): 0,1,2
+        // Shard 2 (1-indexed): 3,4,5 -> but only 2 tests shards there are only 7 total
+        self::assertLessThanOrEqual(3, $loader->testCount);
+        self::assertGreaterThan(0, $loader->testCount);
+        self::assertCount($loader->testCount, $loader->tests);
+    }
+
+    public function testShardTestsWithSingleShard(): void
+    {
+        $this->bareOptions['--shards']        = '1/1';
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // With 1 shard, all tests should be included
+        self::assertSame(7, $loader->testCount);
+        self::assertCount(7, $loader->tests);
+    }
+
+    public function testShardTestsWithFirstShard(): void
+    {
+        $this->bareOptions['--shards']        = '1/5';
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // With 7 tests total and 5 shards, shard 1 should get tests at positions 0,1 (first 2 tests)
+        // Tests per shard: ceil(7/5) = 2
+        self::assertLessThanOrEqual(2, $loader->testCount);
+        self::assertGreaterThan(0, $loader->testCount);
+        self::assertCount($loader->testCount, $loader->tests);
+    }
+
+    public function testShardTestsWithLastShard(): void
+    {
+        $this->bareOptions['--shards']        = '5/5';
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // With 7 tests total and 5 shards, shard 5 should get the remaining test
+        // Tests per shard: ceil(7/5) = 2
+        // Shard 5 offset: 2 * 4 = 8, but only 7 tests total, so shard 5 gets 0 tests
+        // Actually, let's recalculate: shards 1-4 get 2 tests each (8 tests), shard 5 gets 0
+        // Wait, we only have 7 tests, so shard 5 should get 0 tests
+        self::assertGreaterThanOrEqual(0, $loader->testCount);
+        self::assertCount($loader->testCount, $loader->tests);
+    }
+
+    public function testNoShardsAppliedByDefault(): void
+    {
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // Without shards, all tests should be loaded
+        self::assertSame(7, $loader->testCount);
+        self::assertCount(7, $loader->tests);
+    }
+
+    public function testShardTestsWithInvalidShard(): void
+    {
+        $this->bareOptions['--shards']        = 'invalid';
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+
+        $loader = $this->loadSuite();
+
+        // Invalid shard format should not apply sharding, load all tests
+        self::assertSame(7, $loader->testCount);
+        self::assertCount(7, $loader->tests);
+    }
+
     private function loadSuite(): SuiteLoader
     {
         $options = $this->createOptionsFromArgv($this->bareOptions);

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -921,7 +921,7 @@ XML;
         $junitOutputFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'junit-shards.xml';
 
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-        $this->bareOptions['--shards']        = '1/2';
+        $this->bareOptions['--shard']         = '1/2';
         $this->bareOptions['--processes']     = '2';
         $this->bareOptions['--log-junit']     = $junitOutputFile;
         $this->bareOptions['--verbose']       = true;
@@ -933,7 +933,7 @@ XML;
         self::assertSame(RunnerInterface::EXCEPTION_EXIT, $runnerResult->exitCode);
 
         // Check that shard info is displayed in verbose output
-        self::assertStringContainsString('Shards:        1/2', $runnerResult->output);
+        self::assertStringContainsString('Shard:         1/2', $runnerResult->output);
         self::assertStringContainsString('Processes:     2', $runnerResult->output);
 
         // Verify that some tests were run (shard 1/2 should run approximately half the tests)
@@ -983,7 +983,7 @@ XML;
         // Now test shard 2/2 to ensure complementary behavior
         $junitOutputFile2 = $this->tmpDir . DIRECTORY_SEPARATOR . 'junit-shards2.xml';
 
-        $this->bareOptions['--shards']    = '2/2';
+        $this->bareOptions['--shard']     = '2/2';
         $this->bareOptions['--log-junit'] = $junitOutputFile2;
 
         $runnerResult2 = $this->runRunner();
@@ -991,7 +991,7 @@ XML;
         // Extended assertions for shard 2/2
         // Note: shard 2/2 gets the success/warning/skipped tests, so exit code is 0
         self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult2->exitCode);
-        self::assertStringContainsString('Shards:        2/2', $runnerResult2->output);
+        self::assertStringContainsString('Shard:         2/2', $runnerResult2->output);
 
         // Extended jUnit log assertions for shard 2/2
         self::assertFileExists($junitOutputFile2);

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -22,8 +22,11 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use Symfony\Component\Process\Process;
 
 use function array_diff;
+use function array_intersect;
+use function array_merge;
 use function array_reverse;
 use function array_unique;
+use function count;
 use function explode;
 use function file_get_contents;
 use function file_put_contents;
@@ -36,6 +39,7 @@ use function preg_match;
 use function preg_match_all;
 use function preg_replace;
 use function scandir;
+use function simplexml_load_string;
 use function sort;
 use function sprintf;
 use function str_replace;
@@ -910,6 +914,124 @@ EOF;
 XML;
 
         self::assertFileMatchesFormat($expectedXml, $opencloverFile);
+    }
+
+    public function testShardsWithExtendedAssertions(): void
+    {
+        $junitOutputFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'junit-shards.xml';
+
+        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
+        $this->bareOptions['--shards']        = '1/2';
+        $this->bareOptions['--processes']     = '2';
+        $this->bareOptions['--log-junit']     = $junitOutputFile;
+        $this->bareOptions['--verbose']       = true;
+
+        $runnerResult = $this->runRunner();
+
+        // Extended output assertions
+        // Note: common_results fixture contains intentional errors/failures, so exit code will be 2
+        self::assertSame(RunnerInterface::EXCEPTION_EXIT, $runnerResult->exitCode);
+
+        // Check that shard info is displayed in verbose output
+        self::assertStringContainsString('Shards:        1/2', $runnerResult->output);
+        self::assertStringContainsString('Processes:     2', $runnerResult->output);
+
+        // Verify that some tests were run (shard 1/2 should run approximately half the tests)
+        self::assertStringContainsString('4 / 4 (100%)', $runnerResult->output);
+        self::assertStringContainsString('ERRORS!', $runnerResult->output); // Expected due to fixture content
+
+        // Verify final summary shows successful execution
+        self::assertStringContainsString('Time:', $runnerResult->output);
+        self::assertStringContainsString('Memory:', $runnerResult->output);
+
+        // Extended jUnit log assertions
+        self::assertFileExists($junitOutputFile);
+        $junitContent = file_get_contents($junitOutputFile);
+        self::assertNotFalse($junitContent, 'JUnit file should be readable');
+
+        // Parse XML and verify structure
+        $xml = simplexml_load_string($junitContent);
+        self::assertNotFalse($xml, 'JUnit XML should be valid');
+
+        // Access the actual testsuite element (not testsuites)
+        $testsuite = $xml->testsuite[0];
+
+        // Verify testsuite attributes
+        self::assertGreaterThan(0, (int) $testsuite['tests'], 'Should have executed some tests in shard 1/2');
+        self::assertLessThan(7, (int) $testsuite['tests'], 'Should not have executed all 7 tests (only shard 1/2)');
+        // Note: common_results fixture has intentional failures and errors, so we expect some
+        self::assertGreaterThanOrEqual(0, (int) $testsuite['failures'], 'May have failures due to fixture content');
+        self::assertGreaterThanOrEqual(0, (int) $testsuite['errors'], 'May have errors due to fixture content');
+
+        // Verify testcase elements exist (they're nested within testsuite elements)
+        $allTestcases = [];
+        foreach ($testsuite->testsuite as $subTestsuite) {
+            foreach ($subTestsuite->testcase as $testcase) {
+                $allTestcases[] = $testcase;
+            }
+        }
+
+        self::assertGreaterThan(0, count($allTestcases), 'Should have testcase elements in XML');
+
+        // Verify each testcase has required attributes
+        foreach ($allTestcases as $testcase) {
+            self::assertNotEmpty((string) $testcase['name'], 'Each testcase should have a name');
+            self::assertNotEmpty((string) $testcase['class'], 'Each testcase should have a class');
+            self::assertGreaterThanOrEqual(0, (float) $testcase['time'], 'Each testcase should have a valid time');
+        }
+
+        // Now test shard 2/2 to ensure complementary behavior
+        $junitOutputFile2 = $this->tmpDir . DIRECTORY_SEPARATOR . 'junit-shards2.xml';
+
+        $this->bareOptions['--shards']    = '2/2';
+        $this->bareOptions['--log-junit'] = $junitOutputFile2;
+
+        $runnerResult2 = $this->runRunner();
+
+        // Extended assertions for shard 2/2
+        // Note: shard 2/2 gets the success/warning/skipped tests, so exit code is 0
+        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult2->exitCode);
+        self::assertStringContainsString('Shards:        2/2', $runnerResult2->output);
+
+        // Extended jUnit log assertions for shard 2/2
+        self::assertFileExists($junitOutputFile2);
+        $junitContent2 = file_get_contents($junitOutputFile2);
+        self::assertNotFalse($junitContent2, 'Second JUnit file should be readable');
+
+        $xml2 = simplexml_load_string($junitContent2);
+        self::assertNotFalse($xml2, 'Second JUnit XML should be valid');
+
+        // Access the testsuite element for shard 2/2
+        $testsuite2 = $xml2->testsuite[0];
+
+        // Verify that both shards together cover all tests
+        $totalTestsFromShards = (int) $testsuite['tests'] + (int) $testsuite2['tests'];
+        self::assertSame(7, $totalTestsFromShards, 'Both shards together should run all 7 tests');
+
+        // Verify no overlap - collect test names from both shards
+        $shard1Tests = [];
+        $shard2Tests = [];
+
+        foreach ($testsuite->testsuite as $subTestsuite) {
+            foreach ($subTestsuite->testcase as $testcase) {
+                $testId        = (string) $testcase['class'] . '::' . (string) $testcase['name'];
+                $shard1Tests[] = $testId;
+            }
+        }
+
+        foreach ($testsuite2->testsuite as $subTestsuite) {
+            foreach ($subTestsuite->testcase as $testcase) {
+                $testId        = (string) $testcase['class'] . '::' . (string) $testcase['name'];
+                $shard2Tests[] = $testId;
+            }
+        }
+
+        $intersection = array_intersect($shard1Tests, $shard2Tests);
+        self::assertEmpty($intersection, 'Shards should not have overlapping tests');
+
+        // Verify all tests are covered between both shards
+        $allTests = array_merge($shard1Tests, $shard2Tests);
+        self::assertSame(7, count($allTests), 'All 7 tests should be distributed between the 2 shards');
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new `--shards` option that allows sharding the test suite into multiple parts.

The main use case is improving CI performance in scenarios where running the full suite in parallel processes still takes too long. By dividing the suite into shards, it becomes possible to run multiple jobs in parallel, each executing only a portion of the tests.

# Usage

The option follows the format --shards X/Y, where:
- Y is the total number of shards to divide the suite into
- X is the index of the shard to run (starting at 1)

## Example:

- `--shards 1/2` runs the first half of the test suite
- `--shards 2/2` runs the second half

# Motivation

In CI environments, test startup and execution time can remain high even with parallel processes. This feature enables distributing the suite across multiple jobs, reducing overall CI runtime and improving feedback speed.