### PR TITLE
Return an empty TestSuite if mainSuite is null

### DIFF
--- a/src/Logging/LogInterpreter.php
+++ b/src/Logging/LogInterpreter.php
@@ -88,7 +88,9 @@ final class LogInterpreter implements MetaProviderInterface
             $this->mergeSuites($mainSuite, $otherSuite);
         }
 
-        assert($mainSuite !== null);
+        if ($mainSuite === null) {
+            return new TestSuite('', 0, 0, 0, 0, 0, 0, 0, 0.0, '', [], []);
+        }
 
         return $mainSuite;
     }

--- a/src/Runners/PHPUnit/ExecutableTest.php
+++ b/src/Runners/PHPUnit/ExecutableTest.php
@@ -101,7 +101,7 @@ abstract class ExecutableTest
         $tempName = null;
     }
 
-  /**
+    /**
      * Returns the path to this test's JUnit temp file.
      * If the temp file does not exist, it will be
      * created.
@@ -121,7 +121,7 @@ abstract class ExecutableTest
         $this->unlinkTempFile($this->coverageFileName);
     }
 
-  /**
+    /**
      * Return the last process command.
      */
     final public function getLastCommand(): string


### PR DESCRIPTION
This pull request makes a small but important change to the `mergeReaders` method in `LogInterpreter.php`. The method now handles the case where `$mainSuite` is `null` by returning an empty `TestSuite` instance instead of asserting its existence. This improves the robustness of the code by preventing potential errors when no test suites are available.

- Error handling improvement:
  * Updated `mergeReaders` in `LogInterpreter.php` to return an empty `TestSuite` if `$mainSuite` is `null`, instead of asserting, to handle edge cases more gracefully.