### PR TITLE
Drop `<testsuites>` name attribute that doesn't exist in PHPUnit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,4 @@ regenerate-fixture-results: vendor
 	find test/fixtures/ -type f -name "*.xml" -print0 | xargs -0 sed -i 's#$(PWD)#.#g'
 	find test/fixtures/ -type f -name "*.xml" -print0 | xargs -0 sed -i 's#time="........"#time="1.234567"#g'
 	sed -i 's#name="./test/fixtures/common_results"#name=""#g' test/fixtures/common_results/combined.xml
+	sed -i 's#name="CLI Arguments"#name=""#g' test/fixtures/common_results/combined.xml

--- a/src/JUnit/Writer.php
+++ b/src/JUnit/Writer.php
@@ -23,7 +23,6 @@ use const ENT_XML1;
 /** @internal */
 final readonly class Writer
 {
-    private const TESTSUITES_NAME = 'PHPUnit tests';
     private DOMDocument $document;
 
     public function __construct()
@@ -48,7 +47,6 @@ final readonly class Writer
     {
         $xmlTestsuites = $this->document->createElement('testsuites');
         $xmlTestsuites->appendChild($this->createSuiteNode($testSuite));
-        $xmlTestsuites->setAttribute('name', self::TESTSUITES_NAME);
         $this->document->appendChild($xmlTestsuites);
 
         $xml = $this->document->saveXML();
@@ -60,7 +58,7 @@ final readonly class Writer
     private function createSuiteNode(TestSuite $parentSuite): DOMElement
     {
         $suiteNode = $this->document->createElement('testsuite');
-        $suiteNode->setAttribute('name', $parentSuite->name !== self::TESTSUITES_NAME ? $parentSuite->name : '');
+        $suiteNode->setAttribute('name', $parentSuite->name);
         if ($parentSuite->file !== '') {
             $suiteNode->setAttribute('file', $parentSuite->file);
         }

--- a/test/fixtures/common_results/combined.xml
+++ b/test/fixtures/common_results/combined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="" tests="7" assertions="3" errors="1" failures="1" skipped="2" time="1.234567">
     <testsuite name="ParaTest\Tests\fixtures\common_results\ErrorTest" file="./test/fixtures/common_results/ErrorTest.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="1.234567">
       <testcase name="testError" file="./test/fixtures/common_results/ErrorTest.php" line="13" class="ParaTest\Tests\fixtures\common_results\ErrorTest" classname="ParaTest.Tests.fixtures.common_results.ErrorTest" assertions="0" time="1.234567">

--- a/test/fixtures/common_results/junit/ErrorTest.xml
+++ b/test/fixtures/common_results/junit/ErrorTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\ErrorTest" file="./test/fixtures/common_results/ErrorTest.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="1.234567">
     <testcase name="testError" file="./test/fixtures/common_results/ErrorTest.php" line="13" class="ParaTest\Tests\fixtures\common_results\ErrorTest" classname="ParaTest.Tests.fixtures.common_results.ErrorTest" assertions="0" time="1.234567">
       <error type="RuntimeException">ParaTest\Tests\fixtures\common_results\ErrorTest::testError

--- a/test/fixtures/common_results/junit/FailureTest.xml
+++ b/test/fixtures/common_results/junit/FailureTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\FailureTest" file="./test/fixtures/common_results/FailureTest.php" tests="1" assertions="1" errors="0" failures="1" skipped="0" time="1.234567">
     <testcase name="testFailure" file="./test/fixtures/common_results/FailureTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\FailureTest" classname="ParaTest.Tests.fixtures.common_results.FailureTest" assertions="1" time="1.234567">
       <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\common_results\FailureTest::testFailure

--- a/test/fixtures/common_results/junit/IncompleteTest.xml
+++ b/test/fixtures/common_results/junit/IncompleteTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\IncompleteTest" file="./test/fixtures/common_results/IncompleteTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="1" time="1.234567">
     <testcase name="testIncomplete" file="./test/fixtures/common_results/IncompleteTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\IncompleteTest" classname="ParaTest.Tests.fixtures.common_results.IncompleteTest" assertions="0" time="1.234567">
       <skipped/>

--- a/test/fixtures/common_results/junit/RiskyTest.xml
+++ b/test/fixtures/common_results/junit/RiskyTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\RiskyTest" file="./test/fixtures/common_results/RiskyTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testRisky" file="./test/fixtures/common_results/RiskyTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\RiskyTest" classname="ParaTest.Tests.fixtures.common_results.RiskyTest" assertions="0" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/common_results/junit/SkippedTest.xml
+++ b/test/fixtures/common_results/junit/SkippedTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\SkippedTest" file="./test/fixtures/common_results/SkippedTest.php" tests="1" assertions="0" errors="0" failures="0" skipped="1" time="1.234567">
     <testcase name="testSkipped" file="./test/fixtures/common_results/SkippedTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\SkippedTest" classname="ParaTest.Tests.fixtures.common_results.SkippedTest" assertions="0" time="1.234567">
       <skipped/>

--- a/test/fixtures/common_results/junit/SuccessTest.xml
+++ b/test/fixtures/common_results/junit/SuccessTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\SuccessTest" file="./test/fixtures/common_results/SuccessTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testSuccess" file="./test/fixtures/common_results/SuccessTest.php" line="12" class="ParaTest\Tests\fixtures\common_results\SuccessTest" classname="ParaTest.Tests.fixtures.common_results.SuccessTest" assertions="1" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/common_results/junit/WarningTest.xml
+++ b/test/fixtures/common_results/junit/WarningTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\common_results\WarningTest" file="./test/fixtures/common_results/WarningTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
     <testcase name="testWarning" file="./test/fixtures/common_results/WarningTest.php" line="16" class="ParaTest\Tests\fixtures\common_results\WarningTest" classname="ParaTest.Tests.fixtures.common_results.WarningTest" assertions="1" time="1.234567"/>
   </testsuite>

--- a/test/fixtures/github/GH997/worker_tmp_junit.xml
+++ b/test/fixtures/github/GH997/worker_tmp_junit.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.003250">
-        <testcase name="testSuccessOne" file="test/fixtures/github/GH997/SuccessfulTests.php" line="12" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="0.003250"/>
+    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
+        <testcase name="testSuccessOne" file="test/fixtures/github/GH997/SuccessfulTests.php" line="12" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="1.234567"/>
     </testsuite>
-    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.001141">
-        <testcase name="testSuccessTwo" file="test/fixtures/github/GH997/SuccessfulTests.php" line="17" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="0.001141"/>
+    <testsuite name="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" file="test/fixtures/github/GH997/SuccessfulTests.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="1.234567">
+        <testcase name="testSuccessTwo" file="test/fixtures/github/GH997/SuccessfulTests.php" line="17" class="ParaTest\Tests\fixtures\github\GH997\SuccessfulTests" classname="ParaTest.Tests.fixtures.github.GH997.SuccessfulTests" assertions="1" time="1.234567"/>
     </testsuite>
 </testsuites>

--- a/test/fixtures/special_chars/data-provider-with-special-chars.xml
+++ b/test/fixtures/special_chars/data-provider-with-special-chars.xml
@@ -1,298 +1,300 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="PHPUnit tests">
+<testsuites>
   <testsuite name="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" tests="42" assertions="42" errors="0" failures="42" skipped="0" time="1.234567">
     <testsuite name="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse" tests="42" assertions="42" errors="0" failures="42" skipped="0" time="1.234567">
-      <testcase name="testIsItFalse with data set #0" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #0" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #0
+0
 Failed asserting that '' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #1" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #1" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #1
 65
 Failed asserting that 'A' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #2" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #2" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #2
 92
 Failed asserting that '\' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #3" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #3" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #3
 124
 Failed asserting that '|' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #4" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #4" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #4
 33
 Failed asserting that '!' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #5" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #5" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #5
 34
 Failed asserting that '"' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #6" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #6" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #6
 194
 Failed asserting that '£' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #7" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #7" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #7
 36
 Failed asserting that '$' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #8" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #8" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #8
 37
 Failed asserting that '%' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #9" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #9" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #9
 38
 Failed asserting that '&amp;' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #10" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #10" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #10
 40
 Failed asserting that '(' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #11" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #11" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #11
 41
 Failed asserting that ')' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #12" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #12" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #12
 61
 Failed asserting that '=' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #13" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #13" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #13
 63
 Failed asserting that '?' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #14" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #14" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #14
 195
 Failed asserting that 'à' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #15" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #15" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #15
 195
 Failed asserting that 'è' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #16" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #16" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #16
 195
 Failed asserting that 'ì' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #17" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #17" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #17
 195
 Failed asserting that 'ò' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #18" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #18" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #18
 195
 Failed asserting that 'ù' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #19" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #19" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #19
 195
 Failed asserting that 'À' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #20" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #20" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #20
 195
 Failed asserting that 'È' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #21" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #21" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #21
 195
 Failed asserting that 'Ì' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #22" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #22" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #22
 195
 Failed asserting that 'Ò' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #23" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #23" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #23
 195
 Failed asserting that 'Ù' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #24" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #24" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #24
 60
 Failed asserting that '&lt;' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #25" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #25" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #25
 62
 Failed asserting that '&gt;' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #26" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #26" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #26
 45
 Failed asserting that '-' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #27" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #27" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #27
 95
 Failed asserting that '_' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #28" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #28" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #28
 64
 Failed asserting that '@' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #29" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #29" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #29
 35
 Failed asserting that '#' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #30" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #30" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #30
 91
 Failed asserting that '[' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #31" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #31" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #31
 93
 Failed asserting that ']' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #32" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #32" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #32
 195
 Failed asserting that 'ß' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #33" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #33" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #33
 208
 Failed asserting that 'б' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #34" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #34" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #34
 207
 Failed asserting that 'π' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #35" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #35" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #35
 226
 Failed asserting that '€' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #36" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #36" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #36
 226
 Failed asserting that '✔' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #37" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #37" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #37
 228
 Failed asserting that '你' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #38" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #38" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #38
 217
 Failed asserting that 'ي' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #39" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #39" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #39
 216
 Failed asserting that 'د' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #40" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #40" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #40
 90
 Failed asserting that 'Z' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
-      <testcase name="testIsItFalse with data set #41" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="16" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
+      <testcase name="testIsItFalse with data set #41" file="./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php" line="17" class="ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest" classname="ParaTest.Tests.fixtures.special_chars.UnitTestWithDataProviderSpecialCharsTest" assertions="1" time="1.234567">
         <failure type="PHPUnit\Framework\ExpectationFailedException">ParaTest\Tests\fixtures\special_chars\UnitTestWithDataProviderSpecialCharsTest::testIsItFalse with data set #41
+0
 Failed asserting that '' is false.
 
-./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:18</failure>
+./test/fixtures/special_chars/UnitTestWithDataProviderSpecialCharsTest.php:19</failure>
       </testcase>
     </testsuite>
   </testsuite>


### PR DESCRIPTION
Fix https://github.com/paratestphp/paratest/issues/1041