### PR TITLE
Add support for Symfony 8, drop Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "phpunit/php-timer": "^8",
         "phpunit/phpunit": "^12.4.4",
         "sebastian/environment": "^8.0.3",
-        "symfony/console": "^6.4.20 || ^7.3.4",
-        "symfony/process": "^6.4.20 || ^7.3.4"
+        "symfony/console": "^7.3.4 || ^8.0.0",
+        "symfony/process": "^7.3.4 || ^8.0.0"
     },
     "require-dev": {
         "ext-pcntl": "*",
@@ -57,7 +57,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.8",
         "phpstan/phpstan-strict-rules": "^2.0.7",
-        "symfony/filesystem": "^6.4.13 || ^7.3.2"
+        "symfony/filesystem": "^7.3.2 || ^8.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ParaTestCommand.php
+++ b/src/ParaTestCommand.php
@@ -18,6 +18,7 @@ use function assert;
 use function class_exists;
 use function is_string;
 use function is_subclass_of;
+use function method_exists;
 use function sprintf;
 
 /** @internal */
@@ -45,7 +46,14 @@ final class ParaTestCommand extends Command
 
         $application->setName('ParaTest');
         $application->setVersion(PrettyVersions::getVersion('brianium/paratest')->getPrettyVersion());
-        $application->add($command);
+        // @phpstan-ignore function.alreadyNarrowedType (can be removed when dropping support for Symfony 7.3)
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            // @phpstan-ignore method.deprecated (can be removed when dropping support for Symfony 7.3)
+            $application->add($command);
+        }
+
         $commandName = $command->getName();
         assert($commandName !== null);
         $application->setDefaultCommand($commandName, true);

--- a/test/Unit/ParaTestCommandTest.php
+++ b/test/Unit/ParaTestCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use function assert;
 use function chdir;
 use function getcwd;
+use function method_exists;
 use function uniqid;
 
 /** @internal */
@@ -36,7 +37,13 @@ final class ParaTestCommandTest extends TestCase
         $this->tmpDir = (new TmpDirCreator())->create();
         chdir($this->tmpDir);
         $application = ParaTestCommand::applicationFactory($this->tmpDir);
-        $application->add(new HelpCommand());
+        // @phpstan-ignore function.alreadyNarrowedType (can be removed when dropping support for Symfony 7.3)
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand(new HelpCommand());
+        } else {
+            // @phpstan-ignore method.deprecated (can be removed when dropping support for Symfony 7.3)
+            $application->add(new HelpCommand());
+        }
 
         $this->commandTester = new CommandTester($application->find(ParaTestCommand::COMMAND_NAME));
     }


### PR DESCRIPTION
Adds support for Symfony 8 while still supporting the previous versions.

Closes #1053
Closes #1052
Closes #1051