### PR TITLE
Fix: Detect and fail when workers crash after test execution but before writing result files

### DIFF
--- a/src/WrapperRunner/MissingResultsException.php
+++ b/src/WrapperRunner/MissingResultsException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\WrapperRunner;
+
+use RuntimeException;
+
+use function implode;
+use function sprintf;
+
+/** @internal */
+final class MissingResultsException extends RuntimeException
+{
+    /**
+     * @param list<non-empty-string>   $missingFiles
+     * @param 'test_result'|'coverage' $fileType
+     */
+    public static function create(array $missingFiles, string $fileType): self
+    {
+        $fileTypeLabel = $fileType === 'test_result' ? 'test result' : 'coverage';
+
+        $message = sprintf(
+            'One or more workers failed to generate %s files, likely due to unexpected process termination (e.g., out of memory). ' .
+            'Missing %s files: %s',
+            $fileTypeLabel,
+            $fileTypeLabel,
+            implode(', ', $missingFiles),
+        );
+
+        return new self($message);
+    }
+}

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -32,9 +32,10 @@ use function assert;
 use function count;
 use function dirname;
 use function file_get_contents;
+use function filesize;
+use function is_file;
 use function max;
 use function realpath;
-use function spl_object_id;
 use function unlink;
 use function unserialize;
 use function usleep;
@@ -54,8 +55,10 @@ final class WrapperRunner implements RunnerInterface
     private array $workers = [];
     /** @var array<int,int> */
     private array $batches = [];
-    /** @var array<positive-int,WrapperWorker> */
-    private array $workersWithExecutedTests = [];
+    /** @var array<non-empty-string,true> */
+    private array $requiredTestResultFiles = [];
+    /** @var array<non-empty-string,true> */
+    private array $requiredCoverageFiles = [];
 
     /** @var list<SplFileInfo> */
     private array $statusFiles = [];
@@ -176,7 +179,10 @@ final class WrapperRunner implements RunnerInterface
     private function flushWorker(WrapperWorker $worker): void
     {
         if ($worker->hasExecutedTests()) {
-            $this->workersWithExecutedTests[spl_object_id($worker)] = $worker;
+            $this->requiredTestResultFiles[$worker->testResultFile->getPathname()] = true;
+            if (isset($worker->coverageFile)) {
+                $this->requiredCoverageFiles[$worker->coverageFile->getPathname()] = true;
+            }
         }
 
         $this->exitcode = max($this->exitcode, $worker->getExitCode());
@@ -269,12 +275,12 @@ final class WrapperRunner implements RunnerInterface
     {
         // Validate test result files for workers that executed tests
         $missingTestResultFiles = [];
-        foreach ($this->workersWithExecutedTests as $worker) {
-            if ($worker->testResultFile->isFile()) {
+        foreach ($this->requiredTestResultFiles as $filePath => $true) {
+            if (is_file($filePath)) {
                 continue;
             }
 
-            $missingTestResultFiles[] = $worker->testResultFile->getPathname();
+            $missingTestResultFiles[] = $filePath;
         }
 
         if ($missingTestResultFiles !== []) {
@@ -368,16 +374,12 @@ final class WrapperRunner implements RunnerInterface
 
         // Validate coverage files for workers that executed tests
         $missingCoverageFiles = [];
-        foreach ($this->workersWithExecutedTests as $worker) {
-            if (! isset($worker->coverageFile)) {
+        foreach ($this->requiredCoverageFiles as $filePath => $true) {
+            if (is_file($filePath) && filesize($filePath) !== 0) {
                 continue;
             }
 
-            if ($worker->coverageFile->isFile() && $worker->coverageFile->getSize() !== 0) {
-                continue;
-            }
-
-            $missingCoverageFiles[] = $worker->coverageFile->getPathname();
+            $missingCoverageFiles[] = $filePath;
         }
 
         if ($missingCoverageFiles !== []) {

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -179,8 +179,12 @@ final class WrapperRunner implements RunnerInterface
     private function flushWorker(WrapperWorker $worker): void
     {
         if ($worker->hasExecutedTests()) {
-            $this->requiredTestResultFiles[$worker->testResultFile->getPathname()] = true;
-            if (isset($worker->coverageFile)) {
+            $testResultFile = $worker->testResultFile->getPathname();
+            if ($testResultFile !== '') {
+                $this->requiredTestResultFiles[$testResultFile] = true;
+            }
+
+            if (isset($worker->coverageFile) && $worker->coverageFile->getPathname() !== '') {
                 $this->requiredCoverageFiles[$worker->coverageFile->getPathname()] = true;
             }
         }

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -34,6 +34,7 @@ use function dirname;
 use function file_get_contents;
 use function max;
 use function realpath;
+use function spl_object_id;
 use function unlink;
 use function unserialize;
 use function usleep;
@@ -53,6 +54,8 @@ final class WrapperRunner implements RunnerInterface
     private array $workers = [];
     /** @var array<int,int> */
     private array $batches = [];
+    /** @var array<positive-int,WrapperWorker> */
+    private array $workersWithExecutedTests = [];
 
     /** @var list<SplFileInfo> */
     private array $statusFiles = [];
@@ -172,6 +175,10 @@ final class WrapperRunner implements RunnerInterface
 
     private function flushWorker(WrapperWorker $worker): void
     {
+        if ($worker->hasExecutedTests()) {
+            $this->workersWithExecutedTests[spl_object_id($worker)] = $worker;
+        }
+
         $this->exitcode = max($this->exitcode, $worker->getExitCode());
         $this->printer->printFeedback(
             $worker->progressFile,
@@ -260,6 +267,20 @@ final class WrapperRunner implements RunnerInterface
 
     private function complete(TestResult $testResultSum): int
     {
+        // Validate test result files for workers that executed tests
+        $missingTestResultFiles = [];
+        foreach ($this->workersWithExecutedTests as $worker) {
+            if ($worker->testResultFile->isFile()) {
+                continue;
+            }
+
+            $missingTestResultFiles[] = $worker->testResultFile->getPathname();
+        }
+
+        if ($missingTestResultFiles !== []) {
+            throw MissingResultsException::create($missingTestResultFiles, 'test_result');
+        }
+
         foreach ($this->testResultFiles as $testresultFile) {
             if (! $testresultFile->isFile()) {
                 continue;
@@ -343,6 +364,24 @@ final class WrapperRunner implements RunnerInterface
     {
         if ($this->coverageFiles === []) {
             return;
+        }
+
+        // Validate coverage files for workers that executed tests
+        $missingCoverageFiles = [];
+        foreach ($this->workersWithExecutedTests as $worker) {
+            if (! isset($worker->coverageFile)) {
+                continue;
+            }
+
+            if ($worker->coverageFile->isFile() && $worker->coverageFile->getSize() !== 0) {
+                continue;
+            }
+
+            $missingCoverageFiles[] = $worker->coverageFile->getPathname();
+        }
+
+        if ($missingCoverageFiles !== []) {
+            throw MissingResultsException::create($missingCoverageFiles, 'coverage');
         }
 
         $coverageManager = new CodeCoverage();

--- a/src/WrapperRunner/WrapperWorker.php
+++ b/src/WrapperRunner/WrapperWorker.php
@@ -230,4 +230,9 @@ final class WrapperWorker
     {
         return $this->process->isRunning();
     }
+
+    public function hasExecutedTests(): bool
+    {
+        return $this->inExecution > 0;
+    }
 }

--- a/test/Unit/WrapperRunner/MissingResultsExceptionTest.php
+++ b/test/Unit/WrapperRunner/MissingResultsExceptionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\Unit\WrapperRunner;
+
+use ParaTest\WrapperRunner\MissingResultsException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+#[CoversClass(MissingResultsException::class)]
+final class MissingResultsExceptionTest extends TestCase
+{
+    /**
+     * @param non-empty-string                 $fileType
+     * @param non-empty-list<non-empty-string> $missingFiles
+     * @param non-empty-string                 $expectedFileTypeLabel
+     */
+    #[DataProvider('provideFileTypesAndPaths')]
+    public function testCreateExceptionWithMissingFiles(
+        string $fileType,
+        array $missingFiles,
+        string $expectedFileTypeLabel
+    ): void {
+        $exception = MissingResultsException::create($missingFiles, $fileType);
+
+        $message = $exception->getMessage();
+
+        // Verify the exception message contains key information
+        self::assertStringContainsString('One or more workers failed to generate', $message);
+        self::assertStringContainsString($expectedFileTypeLabel, $message);
+        self::assertStringContainsString('unexpected process termination', $message);
+        self::assertStringContainsString('out of memory', $message);
+        self::assertStringContainsString('Missing', $message);
+
+        // Verify all missing files are listed
+        foreach ($missingFiles as $file) {
+            self::assertStringContainsString($file, $message);
+        }
+    }
+
+    /** @return iterable<string, array{string, list<non-empty-string>, string}> */
+    public static function provideFileTypesAndPaths(): iterable
+    {
+        yield 'single test result file' => [
+            'test_result',
+            ['/tmp/worker_01_test_result'],
+            'test result',
+        ];
+
+        yield 'multiple test result files' => [
+            'test_result',
+            [
+                '/tmp/worker_01_test_result',
+                '/tmp/worker_02_test_result',
+                '/tmp/worker_03_test_result',
+            ],
+            'test result',
+        ];
+
+        yield 'single coverage file' => [
+            'coverage',
+            ['/tmp/worker_01_coverage'],
+            'coverage',
+        ];
+
+        yield 'multiple coverage files' => [
+            'coverage',
+            [
+                '/tmp/worker_01_coverage',
+                '/tmp/worker_02_coverage',
+            ],
+            'coverage',
+        ];
+    }
+
+    public function testExceptionMessageForTestResultFiles(): void
+    {
+        $exception = MissingResultsException::create(['/tmp/test_result'], 'test_result');
+        $message   = $exception->getMessage();
+
+        self::assertStringContainsString('test result files', $message);
+        self::assertStringContainsString('/tmp/test_result', $message);
+    }
+
+    public function testExceptionMessageForCoverageFiles(): void
+    {
+        $exception = MissingResultsException::create(['/tmp/coverage'], 'coverage');
+        $message   = $exception->getMessage();
+
+        self::assertStringContainsString('coverage files', $message);
+        self::assertStringContainsString('/tmp/coverage', $message);
+    }
+}

--- a/test/Unit/WrapperRunner/MissingResultsExceptionTest.php
+++ b/test/Unit/WrapperRunner/MissingResultsExceptionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class MissingResultsExceptionTest extends TestCase
 {
     /**
-     * @param non-empty-string                 $fileType
+     * @param 'coverage'|'test_result'         $fileType
      * @param non-empty-list<non-empty-string> $missingFiles
      * @param non-empty-string                 $expectedFileTypeLabel
      */

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -457,6 +457,45 @@ final class WrapperRunnerTest extends TestBase
         $this->runRunner();
     }
 
+    public function testRaiseExceptionWhenResultFilesAreMissingAfterTestExecution(): void
+    {
+        $this->bareOptions['path'] = $this->fixture('missing_results_tests' . DIRECTORY_SEPARATOR . 'TestThatDeletesResultFilesInShutdown.php');
+
+        $this->expectException(MissingResultsException::class);
+        $this->expectExceptionMessageMatches('/test result files/');
+        $this->expectExceptionMessageMatches('/unexpected process termination/');
+
+        $this->runRunner();
+    }
+
+    public function testRaiseExceptionWhenResultAndCoverageFilesAreMissingAfterTestExecution(): void
+    {
+        $this->bareOptions['path']              = $this->fixture('missing_results_tests' . DIRECTORY_SEPARATOR . 'TestThatDeletesResultFilesInShutdown.php');
+        $this->bareOptions['--coverage-php']    = $this->tmpDir . DIRECTORY_SEPARATOR . uniqid('result_');
+        $this->bareOptions['--coverage-filter'] = $this->fixture('missing_results_tests');
+        $this->bareOptions['--cache-directory'] = $this->tmpDir;
+
+        $this->expectException(MissingResultsException::class);
+        $this->expectExceptionMessageMatches('/test result files/');
+        $this->expectExceptionMessageMatches('/unexpected process termination/');
+
+        $this->runRunner();
+    }
+
+    public function testRaiseExceptionWhenOnlyCoverageFileIsMissingAfterTestExecution(): void
+    {
+        $this->bareOptions['path']              = $this->fixture('missing_results_tests' . DIRECTORY_SEPARATOR . 'TestThatDeletesOnlyCoverageFile.php');
+        $this->bareOptions['--coverage-php']    = $this->tmpDir . DIRECTORY_SEPARATOR . uniqid('result_');
+        $this->bareOptions['--coverage-filter'] = $this->fixture('missing_results_tests');
+        $this->bareOptions['--cache-directory'] = $this->tmpDir;
+
+        $this->expectException(MissingResultsException::class);
+        $this->expectExceptionMessageMatches('/coverage files/');
+        $this->expectExceptionMessageMatches('/unexpected process termination/');
+
+        $this->runRunner();
+    }
+
     public function testExitCodes(): void
     {
         $this->bareOptions['path'] = $this->fixture('common_results' . DIRECTORY_SEPARATOR . 'ErrorTest.php');

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -9,6 +9,7 @@ use ParaTest\JUnit\TestSuite;
 use ParaTest\RunnerInterface;
 use ParaTest\Tests\TestBase;
 use ParaTest\Tests\TmpDirCreator;
+use ParaTest\WrapperRunner\MissingResultsException;
 use ParaTest\WrapperRunner\ResultPrinter;
 use ParaTest\WrapperRunner\WorkerCrashedException;
 use ParaTest\WrapperRunner\WrapperRunner;
@@ -54,6 +55,7 @@ use const PHP_EOL;
 #[CoversClass(WrapperRunner::class)]
 #[CoversClass(WrapperWorker::class)]
 #[CoversClass(WorkerCrashedException::class)]
+#[CoversClass(MissingResultsException::class)]
 #[CoversClass(ResultPrinter::class)]
 #[CoversClass(CoverageMerger::class)]
 #[CoversClass(TestSuite::class)]

--- a/test/fixtures/missing_results_tests/TestThatDeletesOnlyCoverageFile.php
+++ b/test/fixtures/missing_results_tests/TestThatDeletesOnlyCoverageFile.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\missing_results_tests;
+
+use PHPUnit\Framework\TestCase;
+
+use function file_exists;
+use function register_shutdown_function;
+use function unlink;
+use function unserialize;
+use function usleep;
+
+/**
+ * This test simulates the scenario where the test result file is written successfully,
+ * but the coverage file is missing (e.g., OOM during coverage file generation).
+ *
+ * @internal
+ */
+final class TestThatDeletesOnlyCoverageFile extends TestCase
+{
+    public function testThatSucceedsButDeletesCoverageFile(): void
+    {
+        register_shutdown_function(static function (): void {
+            $coverageFile = null;
+
+            /** @var array<int,string> $argv */
+            $argv = $_SERVER['argv'] ?? [];
+
+            foreach ($argv as $i => $arg) {
+                if ($arg !== '--phpunit-argv' || ! isset($argv[$i + 1])) {
+                    continue;
+                }
+
+                /** @var array<int,string> $phpunitArgv */
+                $phpunitArgv = unserialize($argv[$i + 1]);
+                foreach ($phpunitArgv as $j => $phpunitArg) {
+                    if ($phpunitArg === '--coverage-php' && isset($phpunitArgv[$j + 1])) {
+                        $coverageFile = $phpunitArgv[$j + 1];
+                        break 2;
+                    }
+                }
+            }
+
+            if ($coverageFile === null) {
+                return;
+            }
+
+            $maxAttempts = 100;
+            $attempt     = 0;
+            while (! file_exists($coverageFile) && $attempt < $maxAttempts) {
+                usleep(10000); // 10ms
+                ++$attempt;
+            }
+
+            if (! file_exists($coverageFile)) {
+                return;
+            }
+
+            unlink($coverageFile);
+        });
+
+        self::assertTrue(true);
+    }
+}

--- a/test/fixtures/missing_results_tests/TestThatDeletesResultFilesInShutdown.php
+++ b/test/fixtures/missing_results_tests/TestThatDeletesResultFilesInShutdown.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\missing_results_tests;
+
+use PHPUnit\Framework\TestCase;
+
+use function file_exists;
+use function register_shutdown_function;
+use function unlink;
+use function usleep;
+
+/**
+ * This test simulates the scenario where a worker process crashes after test execution
+ * but before result files are properly written (e.g., due to OOM during clean-up).
+ *
+ * It registers a shutdown function that waits for files to be written, then deletes them,
+ * simulating the case where application->end() is interrupted before completion.
+ *
+ * @internal
+ */
+final class TestThatDeletesResultFilesInShutdown extends TestCase
+{
+    public function testThatSucceedsButDeletesResultFiles(): void
+    {
+        register_shutdown_function(static function (): void {
+            $testResultFile = null;
+            $coverageFile   = null;
+
+            /** @var array<int,string> $argv */
+            $argv = $_SERVER['argv'] ?? [];
+
+            foreach ($argv as $i => $arg) {
+                if ($arg === '--test-result-file' && isset($argv[$i + 1])) {
+                    $testResultFile = $argv[$i + 1];
+                }
+
+                if ($arg !== '--coverage-php' || ! isset($argv[$i + 1])) {
+                    continue;
+                }
+
+                $coverageFile = $argv[$i + 1];
+            }
+
+            if ($testResultFile !== null) {
+                $maxAttempts = 100;
+                $attempt     = 0;
+                while (! file_exists($testResultFile) && $attempt < $maxAttempts) {
+                    usleep(10000); // 10ms
+                    ++$attempt;
+                }
+
+                if (file_exists($testResultFile)) {
+                    unlink($testResultFile);
+                }
+            }
+
+            if ($coverageFile === null) {
+                return;
+            }
+
+            $maxAttempts = 100;
+            $attempt     = 0;
+            while (! file_exists($coverageFile) && $attempt < $maxAttempts) {
+                usleep(10000); // 10ms
+                ++$attempt;
+            }
+
+            if (! file_exists($coverageFile)) {
+                return;
+            }
+
+            unlink($coverageFile);
+        });
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
#  Problem

When a child process crashes unexpectedly (e.g., due to out-of-memory errors) after executing tests but before writing result/coverage files, Paratest would silently ignore the missing files and exit with code 0. This causes false-positive CI pipeline passes despite test failures.

## Scenario

1. Test executes and reports error (E) in output
2. Status file is written (worker marked as "free")
3. Process crashes due to OOM before `application->end()` completes
4. Result/coverage files are never written
5. Paratest exits successfully (exit code 0)

# Solution

Added validation to ensure all workers that executed tests have written their result and coverage files. If files are missing, throw `MissingResultsException` with a clear error message.

## Changes

- Added `WrapperWorker::hasExecutedTests()` to track which workers ran tests
- Added `WrapperRunner::$requiredTestResultFiles` and `$requiredCoverageFiles` to track file paths that must exist
- Validate test result files only for workers that executed tests (not idle workers)
- Validate coverage files only for workers that executed tests and have coverage enabled
- Throw `MissingResultsException` with actionable error message when files are missing

## Testing

- New `MissingResultsException` unit tests verify exception behaviour
- Validated fixes in a code base which replicates the issue which this pull request solves

## Fixes

Addresses the issue where Paratest would pass CI despite worker crashes when using `--passthru-php='-dmemory_limit=1G'` or similar memory constraints.

### Screenshot

Screenshot demonstrating the exception raising when test result files are missing for a given worker:

<img width="2774" height="986" alt="image" src="https://github.com/user-attachments/assets/dd1f9a39-57fd-45b0-b3dd-71bff16e9db1" />
