### PR TITLE
Add renovate.json to export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /phpstan.neon                   export-ignore
 /phpstan-baseline.neon          export-ignore
 /phpunit.xml                    export-ignore
+/renovate.json                  export-ignore


### PR DESCRIPTION
With this PR, The archive targets other than src/ will be as follows:


```
 gh api repos/sasezaki/paratest/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
bin/
bin/paratest
bin/paratest_for_phpstorm
bin/phpunit-wrapper.php
composer.json
```