### PR TITLE
Add `--max-processes` option

### DIFF
--- a/test/Unit/OptionsTest.php
+++ b/test/Unit/OptionsTest.php
@@ -49,6 +49,13 @@ final class OptionsTest extends TestBase
         self::assertEquals(Options::getNumberOfCPUCores(), $options->processes);
     }
 
+    public function testAutoProcessesModeWithMaxProcesses(): void
+    {
+        $options = $this->createOptionsFromArgv(['--processes' => 'auto', '--max-processes' => '0']);
+
+        self::assertSame(0, $options->processes);
+    }
+
     public function testPassthru(): void
     {
         $argv = ['--passthru-php' => "'-d' 'zend_extension=xdebug.so'"];


### PR DESCRIPTION
This PR adds a `--max-processes` option that, when used with `--processes=auto`, limits the number of processes so it does not exceed a specified maximum. This is useful when the number of CPU cores on CI servers varies, but you don't want to use all of them in some cases.