### PR TITLE
[7.3.x] Update PHPUnit compatibility to 10.5.62

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/php-code-coverage": "^10.1.7",
         "phpunit/php-file-iterator": "^4.1.0",
         "phpunit/php-timer": "^6.0",
-        "phpunit/phpunit": "^10.4.2",
+        "phpunit/phpunit": "^10.5.62",
         "sebastian/environment": "^6.0.1",
         "symfony/console": "^6.3.4 || ^7.0.0",
         "symfony/process": "^6.3.4 || ^7.0.0"
@@ -53,7 +53,7 @@
         "ext-posix": "*",
         "doctrine/coding-standard": "^12.0.0",
         "infection/infection": "^0.27.6",
-        "phpstan/phpstan": "^1.10.40",
+        "phpstan/phpstan": "^1.12.32",
         "phpstan/phpstan-deprecation-rules": "^1.1.4",
         "phpstan/phpstan-phpunit": "^1.3.15",
         "phpstan/phpstan-strict-rules": "^1.5.2",

--- a/src/WrapperRunner/ApplicationForWrapperWorker.php
+++ b/src/WrapperRunner/ApplicationForWrapperWorker.php
@@ -108,7 +108,7 @@ final class ApplicationForWrapperWorker
 
         $testSuite->run();
 
-        return TestResultFacade::result()->wasSuccessfulIgnoringPhpunitWarnings()
+        return TestResultFacade::result()->wasSuccessful()
             ? RunnerInterface::SUCCESS_EXIT
             : RunnerInterface::FAILURE_EXIT;
     }
@@ -191,7 +191,10 @@ final class ApplicationForWrapperWorker
         }
 
         if (isset($this->testdoxFile)) {
-            $this->testdoxResultCollector = new TestResultCollector(EventFacade::instance());
+            $this->testdoxResultCollector = new TestResultCollector(
+                EventFacade::instance(),
+                $this->configuration->source(),
+            );
         }
 
         TestResultFacade::init();

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -142,7 +142,7 @@ final class SuiteLoader
             if ($test instanceof TestCase) {
                 $refClass = new ReflectionClass($test);
                 $filename = $refClass->getFileName();
-                assert(is_string($filename) && $filename !== '');
+                assert(is_string($filename));
                 $filename = $this->stripCwd($filename);
 
                 yield $filename => $test;

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -293,13 +293,7 @@ final class WrapperRunner implements RunnerInterface
         $this->generateLogs();
 
         $exitcode = (new ShellExitCodeCalculator())->calculate(
-            $this->options->configuration->failOnDeprecation(),
-            $this->options->configuration->failOnEmptyTestSuite(),
-            $this->options->configuration->failOnIncomplete(),
-            $this->options->configuration->failOnNotice(),
-            $this->options->configuration->failOnRisky(),
-            $this->options->configuration->failOnSkipped(),
-            $this->options->configuration->failOnWarning(),
+            $this->options->configuration,
             $testResultSum,
         );
 

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -568,7 +568,7 @@ Time: %s, Memory: %s MB
 There was 1 risky test:
 
 1) ParaTest\Tests\fixtures\unexpected_output\UnexpectedOutputTest::testInvalidLogic
-This test printed output: foobar
+Test code or tested code printed unexpected output: foobar
 
 %s/test/fixtures/unexpected_output/UnexpectedOutputTest.php:%d
 

--- a/test/Unit/WrapperRunner/fixtures/common_results_teamcity_output
+++ b/test/Unit/WrapperRunner/fixtures/common_results_teamcity_output
@@ -1,70 +1,35 @@
-
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\ErrorTest' locationHint='php_qn://%s/test/fixtures/common_results/ErrorTest.php::\ParaTest\Tests\fixtures\common_results\ErrorTest' flowId='%d']
-
 ##teamcity[testStarted name='testError' locationHint='php_qn://%s/test/fixtures/common_results/ErrorTest.php::\ParaTest\Tests\fixtures\common_results\ErrorTest::testError' flowId='%d']
-
 ##teamcity[testFailed name='testError' message='RuntimeException: Error here!' details='%s/test/fixtures/common_results/ErrorTest.php:15|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\ErrorTest' flowId='%d']
-
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\FailureTest' locationHint='php_qn://%s/test/fixtures/common_results/FailureTest.php::\ParaTest\Tests\fixtures\common_results\FailureTest' flowId='%d']
-
 ##teamcity[testStarted name='testFailure' locationHint='php_qn://%s/test/fixtures/common_results/FailureTest.php::\ParaTest\Tests\fixtures\common_results\FailureTest::testFailure' flowId='%d']
-
 ##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%s/test/fixtures/common_results/FailureTest.php:14|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\FailureTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\IncompleteTest' locationHint='php_qn://%s/test/fixtures/common_results/IncompleteTest.php::\ParaTest\Tests\fixtures\common_results\IncompleteTest' flowId='%d']
-
 ##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%s/test/fixtures/common_results/IncompleteTest.php::\ParaTest\Tests\fixtures\common_results\IncompleteTest::testIncomplete' flowId='%d']
-
 ##teamcity[testIgnored name='testIncomplete' message='' details='%s/test/fixtures/common_results/IncompleteTest.php:14|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\IncompleteTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\RiskyTest' locationHint='php_qn://%s/test/fixtures/common_results/RiskyTest.php::\ParaTest\Tests\fixtures\common_results\RiskyTest' flowId='%d']
-
 ##teamcity[testStarted name='testRisky' locationHint='php_qn://%s/test/fixtures/common_results/RiskyTest.php::\ParaTest\Tests\fixtures\common_results\RiskyTest::testRisky' flowId='%d']
-
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\RiskyTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\SkippedTest' locationHint='php_qn://%s/test/fixtures/common_results/SkippedTest.php::\ParaTest\Tests\fixtures\common_results\SkippedTest' flowId='%d']
-
 ##teamcity[testStarted name='testSkipped' locationHint='php_qn://%s/test/fixtures/common_results/SkippedTest.php::\ParaTest\Tests\fixtures\common_results\SkippedTest::testSkipped' flowId='%d']
-
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\SkippedTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\SuccessTest' locationHint='php_qn://%s/test/fixtures/common_results/SuccessTest.php::\ParaTest\Tests\fixtures\common_results\SuccessTest' flowId='%d']
-
 ##teamcity[testStarted name='testSuccess' locationHint='php_qn://%s/test/fixtures/common_results/SuccessTest.php::\ParaTest\Tests\fixtures\common_results\SuccessTest::testSuccess' flowId='%d']
-
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\SuccessTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='ParaTest\Tests\fixtures\common_results\WarningTest' locationHint='php_qn://%s/test/fixtures/common_results/WarningTest.php::\ParaTest\Tests\fixtures\common_results\WarningTest' flowId='%d']
-
 ##teamcity[testStarted name='testWarning' locationHint='php_qn://%s/test/fixtures/common_results/WarningTest.php::\ParaTest\Tests\fixtures\common_results\WarningTest::testWarning' flowId='%d']
-
 ##teamcity[testFinished name='testWarning' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='ParaTest\Tests\fixtures\common_results\WarningTest' flowId='%d']


### PR DESCRIPTION
Fix #1075

All changes are backports from the following commits: e52a4b7b963ea15ca7c28e207c3d21714c605394 e09083e8a31acff8b208d82305aabc940ae5860c d376a229e4ed6707ef1239f96396f46c7570f3b3 a585c346ddf1bec22e51e20b5387607905604a71 cfee22cc949d170e61e7111c89ea9fc86aa02ffb

This should now address the failing tests from #1076 (PHPStan, PHPUnit and phpcs pass locally, with and without `--prefer-lowest`).