### PR TITLE
Add `--shard-test-distribution` with a new `round-robin` method

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -7,6 +7,7 @@ namespace ParaTest;
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 use InvalidArgumentException;
+use ParaTest\WrapperRunner\ShardDistribution;
 use PHPUnit\TextUI\Configuration\Builder;
 use PHPUnit\TextUI\Configuration\Configuration;
 use RuntimeException;
@@ -130,6 +131,7 @@ final readonly class Options
         public bool $functional,
         public int $currentShard,
         public int $totalShards,
+        public ShardDistribution $shardDistribution,
     ) {
         $this->needsTeamcity = $configuration->outputIsTeamCity() || $configuration->hasLogfileTeamcity();
         $this->needsTestdox  = $configuration->outputIsTestDox() || $configuration->hasLogfileTestdoxText() || $configuration->hasLogfileTestdoxHtml();
@@ -221,6 +223,17 @@ final readonly class Options
             }
         }
 
+        $shardDistributionValue = $options['shard-test-distribution'];
+        unset($options['shard-test-distribution']);
+        assert(is_string($shardDistributionValue));
+        $shardDistribution = ShardDistribution::tryFrom($shardDistributionValue);
+        if ($shardDistribution === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid shard-test-distribution value: %s. Valid values are: sequential, round-robin',
+                $shardDistributionValue,
+            ));
+        }
+
         // Must be a static non-customizable reference because ParaTest code
         // is strictly coupled with PHPUnit pinned version
         $phpunit = self::getPhpunitBinary();
@@ -274,6 +287,7 @@ final readonly class Options
             $functional,
             $currentShard,
             $totalShards,
+            $shardDistribution,
         );
     }
 
@@ -352,6 +366,13 @@ final readonly class Options
                 null,
                 InputOption::VALUE_OPTIONAL,
                 '<current>/<total> Run a specific part of the suite',
+            ),
+            new InputOption(
+                'shard-test-distribution',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Distribution strategy for sharding: sequential (default) or round-robin',
+                'sequential',
             ),
 
             // PHPUnit options

--- a/src/WrapperRunner/ResultPrinter.php
+++ b/src/WrapperRunner/ResultPrinter.php
@@ -107,6 +107,7 @@ final class ResultPrinter
 
         if ($this->options->hasShard()) {
             $write('Shard', $this->options->currentShard . '/' . $this->options->totalShards);
+            $write('Distribution', $this->options->shardDistribution->value);
         }
 
         $runtime = 'PHP ' . PHP_VERSION;

--- a/src/WrapperRunner/ShardDistribution.php
+++ b/src/WrapperRunner/ShardDistribution.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\WrapperRunner;
+
+/** @internal */
+enum ShardDistribution: string
+{
+    case Sequential = 'sequential';
+    case RoundRobin = 'round-robin';
+}

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -28,9 +28,11 @@ use ReflectionClass;
 use ReflectionProperty;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_filter;
 use function array_keys;
 use function array_merge;
 use function array_slice;
+use function array_values;
 use function assert;
 use function ceil;
 use function count;
@@ -44,6 +46,8 @@ use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
+
+use const ARRAY_FILTER_USE_KEY;
 
 /** @internal */
 final readonly class SuiteLoader
@@ -225,15 +229,16 @@ final readonly class SuiteLoader
 
     private function shardTests(TestSuite $suite): void
     {
-        $tests = $this->extractTestsInSuite($suite);
+        $tests   = $this->extractTestsInSuite($suite);
+        $shards  = $this->options->totalShards;
+        $current = $this->options->currentShard - 1; // 0 indexed. Shard 1 is in reality shard 0
 
-        $shards        = $this->options->totalShards;
-        $current       = $this->options->currentShard - 1; // 0 indexed. Shard 1 is in reality shard 0
-        $total         = count($tests);
-        $testsPerShard = (int) ceil($total / $shards);
-        $offset        = $testsPerShard * $current;
+        $shardedTests = match ($this->options->shardDistribution) {
+            ShardDistribution::Sequential => array_slice($tests, (int) ceil(count($tests) / $shards) * $current, (int) ceil(count($tests) / $shards)),
+            ShardDistribution::RoundRobin => array_values(array_filter($tests, static fn (int $i): bool => $i % $shards === $current, ARRAY_FILTER_USE_KEY)),
+        };
 
-        $suite->setTests(array_slice($tests, $offset, $testsPerShard));
+        $suite->setTests($shardedTests);
     }
 
     /** @return list<Test> */

--- a/test/Unit/OptionsTest.php
+++ b/test/Unit/OptionsTest.php
@@ -7,6 +7,7 @@ namespace ParaTest\Tests\Unit;
 use InvalidArgumentException;
 use ParaTest\Options;
 use ParaTest\Tests\TestBase;
+use ParaTest\WrapperRunner\ShardDistribution;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -216,5 +217,34 @@ final class OptionsTest extends TestBase
         self::assertSame(0, $options->currentShard);
         self::assertSame(0, $options->totalShards);
         self::assertFalse($options->hasShard());
+    }
+
+    public function testShardTestDistributionDefaultsToSequential(): void
+    {
+        $options = $this->createOptionsFromArgv([], __DIR__);
+
+        self::assertSame(ShardDistribution::Sequential, $options->shardDistribution);
+    }
+
+    public function testShardTestDistributionSequentialExplicit(): void
+    {
+        $options = $this->createOptionsFromArgv(['--shard-test-distribution' => 'sequential'], __DIR__);
+
+        self::assertSame(ShardDistribution::Sequential, $options->shardDistribution);
+    }
+
+    public function testShardTestDistributionRoundRobin(): void
+    {
+        $options = $this->createOptionsFromArgv(['--shard-test-distribution' => 'round-robin'], __DIR__);
+
+        self::assertSame(ShardDistribution::RoundRobin, $options->shardDistribution);
+    }
+
+    public function testShardTestDistributionInvalidValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid shard-test-distribution value: invalid');
+
+        $this->createOptionsFromArgv(['--shard-test-distribution' => 'invalid'], __DIR__);
     }
 }

--- a/test/Unit/WrapperRunner/ResultPrinterTest.php
+++ b/test/Unit/WrapperRunner/ResultPrinterTest.php
@@ -135,6 +135,20 @@ final class ResultPrinterTest extends TestBase
         $contents      = $this->getStartOutput();
 
         self::assertStringContainsString("Shard:         3/5\n", $contents);
+        self::assertStringContainsString("Distribution:  sequential\n", $contents);
+    }
+
+    public function testStartPrintsShardInfoWithRoundRobin(): void
+    {
+        $this->printer = new ResultPrinter($this->output, $this->createOptionsFromArgv([
+            '--shard' => '2/4',
+            '--shard-test-distribution' => 'round-robin',
+            '--verbose' => true,
+        ]));
+        $contents      = $this->getStartOutput();
+
+        self::assertStringContainsString("Shard:         2/4\n", $contents);
+        self::assertStringContainsString("Distribution:  round-robin\n", $contents);
     }
 
     public function testStartDoesNotPrintShardInfoWhenNotConfigured(): void
@@ -143,6 +157,7 @@ final class ResultPrinterTest extends TestBase
         $contents      = $this->getStartOutput();
 
         self::assertStringNotContainsString('Shard:', $contents);
+        self::assertStringNotContainsString('Distribution:', $contents);
     }
 
     public function testGetHeader(): void

--- a/test/Unit/WrapperRunner/SuiteLoaderTest.php
+++ b/test/Unit/WrapperRunner/SuiteLoaderTest.php
@@ -7,10 +7,13 @@ namespace ParaTest\Tests\Unit\WrapperRunner;
 use ParaTest\Tests\TestBase;
 use ParaTest\WrapperRunner\SuiteLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+use function array_map;
 use function array_shift;
+use function basename;
 use function uniqid;
 
 use const DIRECTORY_SEPARATOR;
@@ -68,52 +71,6 @@ final class SuiteLoaderTest extends TestBase
         self::assertStringContainsString('my_test.phpt', $file);
     }
 
-    public function testShardTestsWithValidShards(): void
-    {
-        $this->bareOptions['--shard']         = '2/3';
-        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-
-        $loader = $this->loadSuite();
-
-        // With 7 tests total and 3 shards, shard 2 should get tests at positions 3,4,5 (0-indexed: 2,3,4)
-        // Tests per shard: ceil(7/3) = 3
-        // Shard 1 (0-indexed): 0,1,2
-        // Shard 2 (1-indexed): 3,4,5 -> but only 2 tests shards there are only 7 total
-        self::assertLessThanOrEqual(3, $loader->testCount);
-        self::assertGreaterThan(0, $loader->testCount);
-        self::assertCount($loader->testCount, $loader->tests);
-    }
-
-    public function testShardTestsWithFirstShard(): void
-    {
-        $this->bareOptions['--shard']         = '1/5';
-        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-
-        $loader = $this->loadSuite();
-
-        // With 7 tests total and 5 shards, shard 1 should get tests at positions 0,1 (first 2 tests)
-        // Tests per shard: ceil(7/5) = 2
-        self::assertLessThanOrEqual(2, $loader->testCount);
-        self::assertGreaterThan(0, $loader->testCount);
-        self::assertCount($loader->testCount, $loader->tests);
-    }
-
-    public function testShardTestsWithLastShard(): void
-    {
-        $this->bareOptions['--shard']         = '5/5';
-        $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
-
-        $loader = $this->loadSuite();
-
-        // With 7 tests total and 5 shards, shard 5 should get the remaining test
-        // Tests per shard: ceil(7/5) = 2
-        // Shard 5 offset: 2 * 4 = 8, but only 7 tests total, so shard 5 gets 0 tests
-        // Actually, let's recalculate: shards 1-4 get 2 tests each (8 tests), shard 5 gets 0
-        // Wait, we only have 7 tests, so shard 5 should get 0 tests
-        self::assertGreaterThanOrEqual(0, $loader->testCount);
-        self::assertCount($loader->testCount, $loader->tests);
-    }
-
     public function testNoShardsAppliedByDefault(): void
     {
         $this->bareOptions['--configuration'] = $this->fixture('phpunit-common_results.xml');
@@ -123,6 +80,95 @@ final class SuiteLoaderTest extends TestBase
         // Without shards, all tests should be loaded
         self::assertSame(7, $loader->testCount);
         self::assertCount(7, $loader->tests);
+    }
+
+    /** @return iterable<string, array{string, string, list<list<string>>}> */
+    public static function shardDistributionProvider(): iterable
+    {
+        yield 'sequential, 2 shards' => [
+            'sequential',
+            '2',
+            [
+                ['ErrorTest.php', 'FailureTest.php', 'IncompleteTest.php', 'RiskyTest.php'],
+                ['SkippedTest.php', 'SuccessTest.php', 'WarningTest.php'],
+            ],
+        ];
+
+        yield 'sequential, 3 shards' => [
+            'sequential',
+            '3',
+            [
+                ['ErrorTest.php', 'FailureTest.php', 'IncompleteTest.php'],
+                ['RiskyTest.php', 'SkippedTest.php', 'SuccessTest.php'],
+                ['WarningTest.php'],
+            ],
+        ];
+
+        yield 'sequential, 5 shards' => [
+            'sequential',
+            '5',
+            [
+                ['ErrorTest.php', 'FailureTest.php'],
+                ['IncompleteTest.php', 'RiskyTest.php'],
+                ['SkippedTest.php', 'SuccessTest.php'],
+                ['WarningTest.php'],
+                [],
+            ],
+        ];
+
+        yield 'round-robin, 2 shards' => [
+            'round-robin',
+            '2',
+            [
+                ['ErrorTest.php', 'IncompleteTest.php', 'SkippedTest.php', 'WarningTest.php'],
+                ['FailureTest.php', 'RiskyTest.php', 'SuccessTest.php'],
+            ],
+        ];
+
+        yield 'round-robin, 3 shards' => [
+            'round-robin',
+            '3',
+            [
+                ['ErrorTest.php', 'RiskyTest.php', 'WarningTest.php'],
+                ['FailureTest.php', 'SkippedTest.php'],
+                ['IncompleteTest.php', 'SuccessTest.php'],
+            ],
+        ];
+
+        yield 'round-robin, 5 shards' => [
+            'round-robin',
+            '5',
+            [
+                ['ErrorTest.php', 'SuccessTest.php'],
+                ['FailureTest.php', 'WarningTest.php'],
+                ['IncompleteTest.php'],
+                ['RiskyTest.php'],
+                ['SkippedTest.php'],
+            ],
+        ];
+    }
+
+    /**
+     * @param non-empty-string   $distribution
+     * @param non-empty-string   $totalShards
+     * @param list<list<string>> $expectedPerShard
+     */
+    #[DataProvider('shardDistributionProvider')]
+    public function testShardDistribution(string $distribution, string $totalShards, array $expectedPerShard): void
+    {
+        $this->bareOptions['--configuration']           = $this->fixture('phpunit-common_results.xml');
+        $this->bareOptions['--shard-test-distribution'] = $distribution;
+
+        foreach ($expectedPerShard as $index => $expected) {
+            $this->bareOptions['--shard'] = ($index + 1) . '/' . $totalShards;
+            self::assertSame($expected, $this->loadSuiteFileNames());
+        }
+    }
+
+    /** @return list<string> */
+    private function loadSuiteFileNames(): array
+    {
+        return array_map(basename(...), $this->loadSuite()->tests);
     }
 
     private function loadSuite(): SuiteLoader


### PR DESCRIPTION
### Summary

- Add --shard-test-distribution option to control how tests are distributed across shards
- Implement round-robin distribution strategy as an alternative to the default sequential (contiguous blocks)
- Display selected distribution strategy in the output header
- Fully backward compatible — existing behavior is unchanged, sequential remains the default

### Motivation

The existing shard distribution assigns tests in contiguous blocks. This works well when test execution times are uniform, but becomes a bottleneck in projects that mix slow integration/feature tests with fast unit tests.

Most projects organize tests under separate namespaces (e.g. Tests\Feature, Tests\Unit), and PHPUnit loads them alphabetically. With sequential distribution, this means feature tests always land on the first shards and unit tests on the last — guaranteeing uneven execution times. This also means a single heavy feature test class can
end up on one specific shard, becoming the bottleneck for the entire pipeline.

Example: Consider a project with 20,000 tests split across 20 shards on 20 AWS ECS nodes:
- 10,000 feature tests (~10 min per 1,000 tests)
- 10,000 unit tests (~1 min per 1,000 tests)

With sequential distribution, the first 10 shards each get 1,000 feature tests (~10 min), while the last 10 shards each get 1,000 unit tests (~1 min). The pipeline waits for the slowest shard, so total wall time is ~10 minutes — with half the nodes sitting idle after just 1 minute.

With round-robin distribution, each shard receives a mix of feature and unit tests (~500 of each). Every node runs for roughly ~5.5 minutes, cutting total pipeline time nearly in half while fully utilizing all nodes.

### Usage

**Default behavior (sequential, unchanged)**
`vendor/bin/paratest --shard=1/20`
                                                                                                                
**Round-robin for balanced execution times**
`vendor/bin/paratest --shard=1/20 --shard-test-distribution=round-robin`