### PR TITLE
Fix JUnit XML missing test cases when merging suites in `--functional` mode

### DIFF
--- a/src/JUnit/TestSuite.php
+++ b/src/JUnit/TestSuite.php
@@ -125,7 +125,7 @@ final readonly class TestSuite
                 continue;
             }
 
-            $suites[$otherSuiteName]->mergeWith($otherSuite);
+            $suites[$otherSuiteName] = $suites[$otherSuiteName]->mergeWith($otherSuite);
         }
 
         ksort($suites);

--- a/test/Unit/JUnitTest.php
+++ b/test/Unit/JUnitTest.php
@@ -83,4 +83,31 @@ final class JUnitTest extends TestCase
         self::assertCount(2, $testSuite->suites['ParaTest\Tests\fixtures\github\GH997\SuccessfulTests']->cases);
         self::assertEquals(2, $testSuite->suites['ParaTest\Tests\fixtures\github\GH997\SuccessfulTests']->tests);
     }
+
+    public function testMergeSameSuiteAcrossWorkers(): void
+    {
+        $junitFiles = [
+            new SplFileInfo(FIXTURES . '/functional_merge/worker1.xml'),
+            new SplFileInfo(FIXTURES . '/functional_merge/worker2.xml'),
+        ];
+
+        $testSuite = (new LogMerger())->merge($junitFiles);
+        self::assertNotNull($testSuite);
+
+        // 3 distinct class suites: ExampleTest (in both), OtherTest, AnotherTest
+        self::assertCount(3, $testSuite->suites);
+        self::assertArrayHasKey('App\Tests\ExampleTest', $testSuite->suites);
+        self::assertArrayHasKey('App\Tests\OtherTest', $testSuite->suites);
+        self::assertArrayHasKey('App\Tests\AnotherTest', $testSuite->suites);
+
+        // ExampleTest appeared in both workers — all 4 cases must be present
+        $exampleSuite = $testSuite->suites['App\Tests\ExampleTest'];
+        self::assertSame(4, $exampleSuite->tests);
+        self::assertSame(4, $exampleSuite->assertions);
+        self::assertCount(4, $exampleSuite->cases);
+        self::assertSame('testOne', $exampleSuite->cases[0]->name);
+        self::assertSame('testTwo', $exampleSuite->cases[1]->name);
+        self::assertSame('testThree', $exampleSuite->cases[2]->name);
+        self::assertSame('testFour', $exampleSuite->cases[3]->name);
+    }
 }

--- a/test/fixtures/functional_merge/worker1.xml
+++ b/test/fixtures/functional_merge/worker1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="App\Tests\ExampleTest" file="tests/ExampleTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.100000">
+    <testcase name="testOne" file="tests/ExampleTest.php" line="10" class="App\Tests\ExampleTest" classname="App.Tests.ExampleTest" assertions="1" time="0.050000"/>
+    <testcase name="testTwo" file="tests/ExampleTest.php" line="15" class="App\Tests\ExampleTest" classname="App.Tests.ExampleTest" assertions="1" time="0.050000"/>
+  </testsuite>
+  <testsuite name="App\Tests\OtherTest" file="tests/OtherTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.050000">
+    <testcase name="testAlpha" file="tests/OtherTest.php" line="10" class="App\Tests\OtherTest" classname="App.Tests.OtherTest" assertions="1" time="0.050000"/>
+  </testsuite>
+</testsuites>

--- a/test/fixtures/functional_merge/worker2.xml
+++ b/test/fixtures/functional_merge/worker2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="App\Tests\ExampleTest" file="tests/ExampleTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.200000">
+    <testcase name="testThree" file="tests/ExampleTest.php" line="20" class="App\Tests\ExampleTest" classname="App.Tests.ExampleTest" assertions="1" time="0.100000"/>
+    <testcase name="testFour" file="tests/ExampleTest.php" line="25" class="App\Tests\ExampleTest" classname="App.Tests.ExampleTest" assertions="1" time="0.100000"/>
+  </testsuite>
+  <testsuite name="App\Tests\AnotherTest" file="tests/AnotherTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.050000">
+    <testcase name="testBeta" file="tests/AnotherTest.php" line="10" class="App\Tests\AnotherTest" classname="App.Tests.AnotherTest" assertions="1" time="0.050000"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
TestSuite::mergeWith() discarded the return value of recursive mergeWith() calls for overlapping nested suites. Since TestSuite is a readonly immutable class, the merged result was silently lost.

This caused JUnit XML output to report fewer <testcase> elements than actually ran when --functional mode split methods from the same class across multiple workers — the summary test count was correct, but CI tools that count <testcase> elements (e.g. Bitbucket) reported a lower number.

<img width="1173" height="586" alt="image" src="https://github.com/user-attachments/assets/ef3d5cd8-4f48-4e3b-9258-14980c239759" />
