### PR TITLE
Fix merged coverage PHP reports

### DIFF
--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -41,7 +41,9 @@ use function file_get_contents;
 use function filesize;
 use function is_file;
 use function max;
+use function preg_match;
 use function realpath;
+use function str_starts_with;
 use function unlink;
 use function unserialize;
 use function usleep;
@@ -417,6 +419,18 @@ final class WrapperRunner implements RunnerInterface
         );
         $codeCoverage = $coverageManager->codeCoverage();
         $codeCoverage->excludeUncoveredFiles();
+        $codeCoverageData = clone $serializedCoverage['codeCoverage'];
+        if ($serializedCoverage['basePath'] !== '') {
+            foreach ($codeCoverageData->coveredFiles() as $file) {
+                if (! self::isRelativePath($file)) {
+                    continue;
+                }
+
+                $codeCoverageData->renameFile($file, $serializedCoverage['basePath'] . DIRECTORY_SEPARATOR . $file);
+            }
+        }
+
+        $codeCoverage->setData($codeCoverageData);
         $codeCoverage->setTests($serializedCoverage['testResults']);
         (new ReflectionProperty(\SebastianBergmann\CodeCoverage\CodeCoverage::class, 'cachedReport'))->setValue($codeCoverage, $report);
 
@@ -424,6 +438,13 @@ final class WrapperRunner implements RunnerInterface
             $this->printer->printer,
             $this->options->configuration,
         );
+    }
+
+    private static function isRelativePath(string $path): bool
+    {
+        return ! str_starts_with($path, 'phar://')
+            && ! str_starts_with($path, DIRECTORY_SEPARATOR)
+            && preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) !== 1;
     }
 
     private function generateJunitLog(): void

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use SebastianBergmann\CodeCoverage\Report\Facade as CoverageReportFacade;
+use SebastianBergmann\CodeCoverage\Serialization\Unserializer;
 use Symfony\Component\Process\Process;
 
 use function array_diff;
@@ -24,6 +26,7 @@ use function array_intersect;
 use function array_merge;
 use function array_reverse;
 use function array_unique;
+use function assert;
 use function count;
 use function explode;
 use function file_get_contents;
@@ -31,6 +34,7 @@ use function file_put_contents;
 use function glob;
 use function implode;
 use function is_file;
+use function is_string;
 use function min;
 use function posix_mkfifo;
 use function preg_match;
@@ -668,6 +672,25 @@ final class WrapperRunnerTest extends TestBase
           Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  1/  1)
         EOF;
         self::assertStringMatchesFormat($expectedContains, $runnerResult->output);
+    }
+
+    public function testCoveragePhpReportContainsMergedCodeCoverageData(): void
+    {
+        $this->bareOptions['path']              = $this->fixture('common_results' . DIRECTORY_SEPARATOR . 'SuccessTest.php');
+        $this->bareOptions['--coverage-php']    = $this->tmpDir . DIRECTORY_SEPARATOR . uniqid('result_');
+        $this->bareOptions['--coverage-filter'] = $this->fixture('common_results');
+        $this->bareOptions['--cache-directory'] = $this->tmpDir;
+
+        $runnerResult = $this->runRunner();
+        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
+
+        $coveragePhpPath = $this->bareOptions['--coverage-php'];
+        assert(is_string($coveragePhpPath));
+
+        $coveragePhp     = (new Unserializer())->unserialize($coveragePhpPath);
+        $coverageSummary = CoverageReportFacade::fromSerializedData($coveragePhp)->summary();
+        self::assertSame(8, $coverageSummary->numberOfExecutableLines());
+        self::assertSame(1, $coverageSummary->numberOfExecutedLines());
     }
 
     public function testHandleCollisionWithSymfonyOutput(): void


### PR DESCRIPTION
When wrapper workers produce serialized coverage files, ParaTest builds a correct cached report for HTML/text reports, but the CodeCoverage instance used by PHPUnit's `--coverage-php` serializer still contains its default empty data. Downstream consumers reading the PHP coverage artifact can then see an empty 0/0 report.

This hydrates the merged coverage data back into the CodeCoverage instance before report generation. Because worker coverage files are already path-reduced, it restores relative file paths against the merged base path first so php-code-coverage can serialize a usable artifact with the right base path.

A regression test deserializes the generated `--coverage-php` file and asserts the merged summary contains the expected executable and executed line counts.
