### PR TITLE
Use class-string type for array keys holding class names

### DIFF
--- a/src/TestDox/TestDoxResultsMerger.php
+++ b/src/TestDox/TestDoxResultsMerger.php
@@ -25,11 +25,11 @@ final readonly class TestDoxResultsMerger
     /**
      * @param list<SplFileInfo> $testdoxFiles
      *
-     * @return array<string, TestResultCollection>
+     * @return array<class-string, TestResultCollection>
      */
     public function getResultsFromTestdoxFiles(array $testdoxFiles): array
     {
-        /** @var array<string, TestResultCollection> $testMethodsGroupedByClass */
+        /** @var array<class-string, TestResultCollection> $testMethodsGroupedByClass */
         $testMethodsGroupedByClass = [];
         foreach ($testdoxFiles as $testdoxFile) {
             if (! $testdoxFile->isFile()) {
@@ -39,7 +39,7 @@ final readonly class TestDoxResultsMerger
             $testdoxFileContents = file_get_contents($testdoxFile->getPathname());
             assert($testdoxFileContents !== false);
 
-            /** @var array<string, TestResultCollection> $testMethodsGroupedByClassInTestdoxFile */
+            /** @var array<class-string, TestResultCollection> $testMethodsGroupedByClassInTestdoxFile */
             $testMethodsGroupedByClassInTestdoxFile = unserialize($testdoxFileContents);
             foreach ($testMethodsGroupedByClassInTestdoxFile as $className => $testResultCollection) {
                 if (! isset($testMethodsGroupedByClass[$className])) {
@@ -58,9 +58,9 @@ final readonly class TestDoxResultsMerger
     }
 
     /**
-     * @param array<string, TestResultCollection> $testdoxResults
+     * @param array<class-string, TestResultCollection> $testdoxResults
      *
-     * @return array<string, TestResultCollection>
+     * @return array<class-string, TestResultCollection>
      */
     private function orderTestdoxResults(array $testdoxResults): array
     {

--- a/src/WrapperRunner/ResultPrinter.php
+++ b/src/WrapperRunner/ResultPrinter.php
@@ -181,7 +181,7 @@ final class ResultPrinter
 
     /**
      * @param list<SplFileInfo>                         $teamcityFiles
-     * @param array<string,TestDoxTestResultCollection> $testdoxResults
+     * @param array<class-string,TestDoxTestResultCollection> $testdoxResults
      */
     public function printResults(TestResult $testResult, array $teamcityFiles, array $testdoxResults): void
     {

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -464,7 +464,7 @@ final class WrapperRunner implements RunnerInterface
         );
     }
 
-    /** @param array<string,TestDoxTestResultCollection> $testdoxResults */
+    /** @param array<class-string,TestDoxTestResultCollection> $testdoxResults */
     private function generateTestDoxLogs(array $testdoxResults): void
     {
         if ($this->options->configuration->hasLogfileTestdoxText()) {

--- a/test/Unit/WrapperRunner/ResultPrinterTest.php
+++ b/test/Unit/WrapperRunner/ResultPrinterTest.php
@@ -288,7 +288,7 @@ final class ResultPrinterTest extends TestBase
     public function testTestdoxOutputWithProgress(): void
     {
         $testdoxResults = [
-            'Std Class' => TestDoxTestResultCollection::fromArray([
+            stdClass::class => TestDoxTestResultCollection::fromArray([
                 new TestDoxTestResult(
                     new TestMethod(stdClass::class, 'bar', 'foo.php', 42, new TestDox('Std Class', 'Bar', 'Bar'), MetadataCollection::fromArray([]), TestDataCollection::fromArray([])),
                     TestStatus::success(),
@@ -318,7 +318,7 @@ final class ResultPrinterTest extends TestBase
     public function testTestdoxOutputWithoutProgress(): void
     {
         $testdoxResults = [
-            'Std Class' => TestDoxTestResultCollection::fromArray([
+            stdClass::class => TestDoxTestResultCollection::fromArray([
                 new TestDoxTestResult(
                     new TestMethod(stdClass::class, 'bar', 'foo.php', 42, new TestDox('Std Class', 'Bar', 'Bar'), MetadataCollection::fromArray([]), TestDataCollection::fromArray([])),
                     TestStatus::success(),


### PR DESCRIPTION
This was failing in PHPStan in my last PR. Should improve the type coverage and fix some PHPStan issues.