### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - "*.x"
       - "renovate/*"
 
+permissions:
+  contents: read
+
 env:
   INI_VALUES: zend.assertions=1,error_reporting=-1,date.timezone="Europe/Rome"
 


### PR DESCRIPTION
Potential fix for [https://github.com/paratestphp/paratest/security/code-scanning/6](https://github.com/paratestphp/paratest/security/code-scanning/6)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `on:` is a common placement). For this CI workflow, the minimal safe baseline is:

- `contents: read`

This keeps existing functionality for checkout and read-only analysis tasks while restricting token scope.  
Given only the shown snippet, the best non-disruptive fix is a **root-level** permissions block so all jobs inherit it consistently without editing each job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
