### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 3 * * 6'
   workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/paratestphp/paratest/security/code-scanning/1](https://github.com/paratestphp/paratest/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/stale.yml` so the `GITHUB_TOKEN` is constrained to only what this workflow needs.

Best fix here (without changing behavior): set workflow-level permissions immediately after `workflow_dispatch` and before `jobs`, granting:
- `contents: read` (safe baseline, common for actions)
- `issues: write` (required for stale bot operations on issues)

Since PR handling is disabled (`days-before-pr-stale: -1` and `days-before-pr-close: -1`), `pull-requests: write` is not required for current functionality and should be omitted to keep least privilege.

No imports, methods, or dependencies are needed—just YAML key insertion in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
