### PR TITLE
bug: fix output count when `--shard` and `#[DataProvider]` are used together

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpunit/php-timer": "^9",
         "phpunit/phpunit": "^13.2.5",
         "sebastian/environment": "^9.3.2",
-        "symfony/console": "^7.4.8 || ^8.1.0",
+        "symfony/console": "^7.4.8 || ^8.1.1",
         "symfony/process": "^7.4.8 || ^8.1.0"
     },
     "require-dev": {

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -7,6 +7,7 @@ namespace ParaTest\WrapperRunner;
 use Generator;
 use ParaTest\Options;
 use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\DataProviderTestSuite;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
@@ -274,7 +275,11 @@ final readonly class SuiteLoader
             }
 
             $children = $item->tests();
-            if ($children !== [] && $children[0] instanceof TestSuite) {
+            if (
+                $children !== []
+                && $children[0] instanceof TestSuite
+                && ! ($children[0] instanceof DataProviderTestSuite)
+            ) {
                 $classSuites = array_merge($classSuites, $this->extractClassSuites($item));
             } else {
                 $classSuites[] = $item;

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -1187,6 +1187,31 @@ XML;
     }
 
     #[Group('github')]
+    public function testShardOnDataProviderShouldReturnCorrectSum(): void
+    {
+        $this->bareOptions['--configuration'] = $this->fixture('github' . DIRECTORY_SEPARATOR . 'GH1120' . DIRECTORY_SEPARATOR . 'phpunit.xml');
+        $this->bareOptions['--shard']         = '2/2';
+        $this->bareOptions['--processes']     = '2';
+
+        $expectedOutput = <<<'EOF'
+Processes:     %s
+Shard:         2/2
+Distribution:  sequential
+Runtime:       PHP %s
+Configuration: %s/test/fixtures/github/GH1120/phpunit.xml
+
+....                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s MB%a
+EOF;
+
+        $runnerResult = $this->runRunner();
+
+        self::assertSame(RunnerInterface::SUCCESS_EXIT, $runnerResult->exitCode);
+        self::assertStringMatchesFormat($expectedOutput, $runnerResult->output);
+    }
+
+    #[Group('github')]
     public function testDeprecationTriggerSpecsAreRespected(): void
     {
         $this->bareOptions['--configuration'] = $this->fixture('github' . DIRECTORY_SEPARATOR . 'GH1081' . DIRECTORY_SEPARATOR . 'phpunit.xml');

--- a/test/fixtures/github/GH1120/phpunit.xml
+++ b/test/fixtures/github/GH1120/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/fixtures/github/GH1120/tests/AlphaTest.php
+++ b/test/fixtures/github/GH1120/tests/AlphaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * 7 tests: 3 x 2 from the providers, 1 plain.
+ *
+ * The FIRST method of this class uses a data provider, so children[0] of the
+ * class-level TestSuite is a DataProviderTestSuite. Since DataProviderTestSuite
+ * extends TestSuite, SuiteLoader::extractClassSuites() mistakes this class for a
+ * wrapper suite, recurses into it, keeps only the three provider methods as shard
+ * items and silently drops testPlain() from the sharded suite.
+ *
+ * Three provider methods are needed so that a shard boundary falls *inside* this
+ * class: with 2 shards the items are
+ *
+ *     [Alpha::first, Alpha::second] [Alpha::third, Bravo]
+ *
+ * so AlphaTest.php is dispatched to both shards and runs twice. With only two
+ * provider methods the boundary would fall exactly between AlphaTest and
+ * BravoTest, and `sequential` would show the wrong testCount but no duplication.
+ */
+final class AlphaTest extends TestCase
+{
+    #[DataProvider('provider')]
+    public function testFirstWithProvider(int $value): void
+    {
+        self::assertGreaterThan(0, $value);
+    }
+
+    #[DataProvider('provider')]
+    public function testSecondWithProvider(int $value): void
+    {
+        self::assertGreaterThan(0, $value);
+    }
+
+    #[DataProvider('provider')]
+    public function testThirdWithProvider(int $value): void
+    {
+        self::assertGreaterThan(0, $value);
+    }
+
+    public function testPlain(): void
+    {
+        self::assertTrue(true);
+    }
+
+    /** @return list<array{int}> */
+    public static function provider(): array
+    {
+        return [[1], [2]];
+    }
+}

--- a/test/fixtures/github/GH1120/tests/BravoTest.php
+++ b/test/fixtures/github/GH1120/tests/BravoTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * 4 tests, no data provider at all.
+ *
+ * Control case: this class is classified correctly, so its shard always reports
+ * 4 / 4 (100%).
+ */
+final class BravoTest extends TestCase
+{
+    public function testOne(): void
+    {
+        self::assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        self::assertTrue(true);
+    }
+
+    public function testThree(): void
+    {
+        self::assertTrue(true);
+    }
+
+    public function testFour(): void
+    {
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
Fix https://github.com/paratestphp/paratest/issues/1120