### PR TITLE
Worker affinities for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,52 @@ public function setUp(): void
 }
 ```
 
+## Test setup caching between tests
+
+Similar to the problem with single initialization in tests. Reusing (cached) data between tests using static
+variables will be less effective when tests are run on different worker processes.
+
+This has two solutions:
+* Share data using the file system. See a comparable solution using single initialization above.
+* Assign affinities to tests to hint that tests should run in the same worker. This is only a hint and not a guarantee.
+
+By default paratest will (without the `--functional` option) assign whole phpunit test cases to a worker.
+Assigning affinities will therefore only be useful if your state can be shared by multiple phpunit test cases.
+
+Assigning an affinity can be done by implementing the AffinityAware interface in your tests.
+
+```php
+final class ExpensiveSingleton
+{
+    private static self $instance;
+    
+    public static function get(): self
+    {
+        self::$instance ??= expensive_setup_logic();
+        return self::$instance;
+    }
+}
+
+//...
+
+use ParaTest\AffinityAware;
+
+final class MyTest extends TestCase implements AffinityAware
+{
+    private ExpensiveSingleton $singleton;
+    
+    protected function setUp(): void
+    {
+        $this->singleton = ExpensiveSingleton::get();
+    }
+
+    public function getAffinity(): string|null
+    {
+        return ExpensiveSingleton::class;
+    }
+}
+```
+
 ## Troubleshooting
 
 If you run into problems with `paratest`, try to get more information about the issue by enabling debug output via

--- a/src/AffinityAware.php
+++ b/src/AffinityAware.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest;
+
+/**
+ * Interface that can be implemented on phpunit test classes.
+ * Tests which share an affinity (any string) are more likely to be scheduled on the same worker process.
+ * This can improve performance when in-memory test setup or exclusive locks are used.
+ * This affinity is only a hint, and not a guarantee.
+ */
+interface AffinityAware
+{
+    public function getAffinity(): string|null;
+}

--- a/src/WrapperRunner/PendingTestQueue.php
+++ b/src/WrapperRunner/PendingTestQueue.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\WrapperRunner;
+
+use function array_shift;
+use function count;
+
+/** @internal */
+final class PendingTestQueue
+{
+    /** @param list<non-empty-string> $pending */
+    public function __construct(
+        private array $pending,
+    ) {
+    }
+
+    /** @param list<non-empty-string> $tests */
+    public static function fromTests(array $tests): self
+    {
+        return new self($tests);
+    }
+
+    public static function fromSuite(Suite $suite): self
+    {
+        return new self($suite->getTests());
+    }
+
+    public function clear(): void
+    {
+        $this->pending = [];
+    }
+
+    public function empty(): bool
+    {
+        return count($this->pending) === 0;
+    }
+
+    /** @return non-empty-string|null */
+    public function dequeue(): ?string
+    {
+        return array_shift($this->pending);
+    }
+}

--- a/src/WrapperRunner/PendingTestQueue.php
+++ b/src/WrapperRunner/PendingTestQueue.php
@@ -4,32 +4,50 @@ declare(strict_types=1);
 
 namespace ParaTest\WrapperRunner;
 
+use LogicException;
+
+use function array_fill_keys;
+use function array_filter;
+use function array_find_key;
+use function array_keys;
 use function array_shift;
+use function assert;
 use function count;
+use function min;
+use function strval;
 
 /** @internal */
 final class PendingTestQueue
 {
-    /** @param list<non-empty-string> $pending */
+    /** @var array<int, string> */
+    private array $workerToAffinity = [];
+    /** @var array<int> */
+    private array $affinityToWorkerCount;
+
+    /** @param array<list<non-empty-string>> $pending */
     public function __construct(
         private array $pending,
     ) {
+        $this->pending               = array_filter($this->pending, static fn (array $pending) => count($pending) > 0);
+        $this->affinityToWorkerCount = array_fill_keys(array_keys($this->pending), 0);
     }
 
     /** @param list<non-empty-string> $tests */
     public static function fromTests(array $tests): self
     {
-        return new self($tests);
+        return new self(['' => $tests]);
     }
 
     public static function fromSuite(Suite $suite): self
     {
-        return new self($suite->getTests());
+        return new self($suite->getTestsPerAffinity());
     }
 
     public function clear(): void
     {
-        $this->pending = [];
+        $this->pending               = [];
+        $this->affinityToWorkerCount = [];
+        $this->workerToAffinity      = [];
     }
 
     public function empty(): bool
@@ -37,9 +55,47 @@ final class PendingTestQueue
         return count($this->pending) === 0;
     }
 
-    /** @return non-empty-string|null */
-    public function dequeue(): ?string
+    private function assignWorkerToAffinity(int $workerToken): string
     {
-        return array_shift($this->pending);
+        if (count($this->affinityToWorkerCount) === 0) {
+            throw new LogicException('Method only expected to be called when there are still tests pending');
+        }
+
+        // Returns affinity with the least amount of workers assigned to it.
+        $min      = min($this->affinityToWorkerCount);
+        $affinity = array_find_key(
+            $this->affinityToWorkerCount,
+            static fn (int $workerCount) => $workerCount === $min,
+        );
+        assert($affinity !== null);
+        $affinity = strval($affinity);
+
+        $this->workerToAffinity[$workerToken]    = $affinity;
+        $this->affinityToWorkerCount[$affinity] += 1;
+
+        return $affinity;
+    }
+
+    /** @return non-empty-string|null */
+    public function dequeue(int $workerToken): ?string
+    {
+        if (count($this->pending) === 0) {
+            return null;
+        }
+
+        $workerAffinity = $this->workerToAffinity[$workerToken] ?? null;
+        if ($workerAffinity === null || isset($this->pending[$workerAffinity]) === false) {
+            $workerAffinity = $this->assignWorkerToAffinity($workerToken);
+        }
+
+        // Will always be non-null, as each entry is a non-empty-list.
+        $pending = array_shift($this->pending[$workerAffinity]);
+        // Remove the entry if it becomes an empty list.
+        if (count($this->pending[$workerAffinity]) === 0) {
+            unset($this->pending[$workerAffinity]);
+            unset($this->affinityToWorkerCount[$workerAffinity]);
+        }
+
+        return $pending;
     }
 }

--- a/src/WrapperRunner/Suite.php
+++ b/src/WrapperRunner/Suite.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace ParaTest\WrapperRunner;
 
+use function array_merge;
+use function array_values;
+
 /** @internal */
 final readonly class Suite
 {
-    /** @param list<non-empty-string> $tests */
+    /** @param array<list<non-empty-string>> $testsPerAffinity */
     public function __construct(
-        private int   $testCount,
-        private array $tests,
+        private int $testCount,
+        private array $testsPerAffinity,
     ) {
     }
 
@@ -19,9 +22,15 @@ final readonly class Suite
         return $this->testCount;
     }
 
+    /** @return array<list<non-empty-string>> */
+    public function getTestsPerAffinity(): array
+    {
+        return $this->testsPerAffinity;
+    }
+
     /** @return list<non-empty-string> */
     public function getTests(): array
     {
-        return $this->tests;
+        return array_merge(...array_values($this->testsPerAffinity));
     }
 }

--- a/src/WrapperRunner/Suite.php
+++ b/src/WrapperRunner/Suite.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\WrapperRunner;
+
+/** @internal */
+final readonly class Suite
+{
+    /** @param list<non-empty-string> $tests */
+    public function __construct(
+        private int   $testCount,
+        private array $tests,
+    ) {
+    }
+
+    public function getTestCount(): int
+    {
+        return $this->testCount;
+    }
+
+    /** @return list<non-empty-string> */
+    public function getTests(): array
+    {
+        return $this->tests;
+    }
+}

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ParaTest\WrapperRunner;
 
 use Generator;
+use ParaTest\AffinityAware;
 use ParaTest\Options;
 use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Framework\Test;
@@ -31,7 +32,6 @@ use ReflectionProperty;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function array_filter;
-use function array_keys;
 use function array_merge;
 use function array_slice;
 use function array_values;
@@ -47,12 +47,15 @@ use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
+use function uasort;
 
 use const ARRAY_FILTER_USE_KEY;
 
 /** @internal */
 final readonly class SuiteLoader
 {
+    private const string DEFAULT_AFFINITY = '';
+
     public function __construct(
         private Options $options,
         private CodeCoverageFilterRegistry $codeCoverageFilterRegistry,
@@ -128,10 +131,24 @@ final readonly class SuiteLoader
 
         if ($this->options->functional) {
             // Functional: The unit of work is an individual test method.
+
+            // Keep a map of files to their affinity to avoid both recalculation and issues when the calculated affinity changes between calls.
+            $fileToAffinity = [];
+
             $tests = [];
             foreach ($this->loadFiles($testSuite) as $file => $test) {
+                $affinity = self::DEFAULT_AFFINITY;
+                if ($test instanceof AffinityAware) {
+                    if (! isset($fileToAffinity[$file])) {
+                        $fileToAffinity[$file] = $test->getAffinity() ?? self::DEFAULT_AFFINITY;
+                    }
+
+                    $affinity = $fileToAffinity[$file];
+                }
+
+                $tests[$affinity] ??= [];
                 if ($test instanceof PhptTestCase) {
-                    $tests[] = $file;
+                    $tests[$affinity][] = $file;
                 } else {
                     $name = $test->name();
                     if ($test->providedData() !== []) {
@@ -140,18 +157,34 @@ final readonly class SuiteLoader
                         $name = sprintf('/%s$/', $name);
                     }
 
-                    $tests[] = "$file\0$name";
+                    $tests[$affinity][] = "$file\0$name";
                 }
             }
         } else {
             // Not functional: The unit of work is a test class consisting of multiple test methods.
             $files = [];
-            foreach ($this->loadFiles($testSuite) as $file => $_) {
-                $files[$file] = null;
+            foreach ($this->loadFiles($testSuite) as $file => $test) {
+                if (isset($files[$file]) === true) {
+                    continue;
+                }
+
+                $affinity     = $test instanceof AffinityAware
+                    ? ($test->getAffinity() ?? self::DEFAULT_AFFINITY)
+                    : self::DEFAULT_AFFINITY;
+                $files[$file] = $affinity;
             }
 
-            $tests = array_keys($files);
+            $tests = [];
+            foreach ($files as $file => $affinity) {
+                $tests[$affinity] ??= [];
+                $tests[$affinity][] = $file;
+            }
         }
+
+        // Sort the tests grouped by affinity. Largest buckets first.
+        uasort($tests, static function (array $a, array $b) {
+            return count($b) <=> count($a);
+        });
 
         $suite = new Suite($testCount, $tests);
 

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -38,7 +38,6 @@ use function array_values;
 use function assert;
 use function ceil;
 use function count;
-use function is_int;
 use function is_string;
 use function mt_srand;
 use function ob_get_clean;
@@ -128,37 +127,34 @@ final readonly class SuiteLoader
 
         $this->testCount = count($testSuite);
 
-        $files = [];
-        $tests = [];
-        foreach ($this->loadFiles($testSuite) as $file => $test) {
-            $files[$file] = null;
-
-            if ($test instanceof PhptTestCase) {
-                $tests[] = $file;
-            } else {
-                $name = $test->name();
-                if ($test->providedData() !== []) {
-                    $dataName = $test->dataName();
-                    if ($this->options->functional) {
+        if ($this->options->functional) {
+            // Functional: The unit of work is an individual test method.
+            $tests = [];
+            foreach ($this->loadFiles($testSuite) as $file => $test) {
+                if ($test instanceof PhptTestCase) {
+                    $tests[] = $file;
+                } else {
+                    $name = $test->name();
+                    if ($test->providedData() !== []) {
                         $name = sprintf('/%s%s$/', preg_quote($name, '/'), preg_quote($test->dataSetAsString(), '/'));
                     } else {
-                        if (is_int($dataName)) {
-                            $name .= '#' . $dataName;
-                        } else {
-                            $name .= '@' . $dataName;
-                        }
+                        $name = sprintf('/%s$/', $name);
                     }
-                } else {
-                    $name = sprintf('/%s$/', $name);
-                }
 
-                $tests[] = "$file\0$name";
+                    $tests[] = "$file\0$name";
+                }
             }
+        } else {
+            // Not functional: The unit of work is a test class consisting of multiple test methods.
+            $files = [];
+            foreach ($this->loadFiles($testSuite) as $file => $_) {
+                $files[$file] = null;
+            }
+
+            $tests = array_keys($files);
         }
 
-        $this->tests = $this->options->functional
-            ? $tests
-            : array_keys($files);
+        $this->tests = $tests;
 
         if (! $this->options->configuration->hasCoverageReport()) {
             return;

--- a/src/WrapperRunner/SuiteLoader.php
+++ b/src/WrapperRunner/SuiteLoader.php
@@ -53,15 +53,14 @@ use const ARRAY_FILTER_USE_KEY;
 /** @internal */
 final readonly class SuiteLoader
 {
-    public int $testCount;
-    /** @var list<non-empty-string> */
-    public array $tests;
-
     public function __construct(
         private Options $options,
-        OutputInterface $output,
-        CodeCoverageFilterRegistry $codeCoverageFilterRegistry,
+        private CodeCoverageFilterRegistry $codeCoverageFilterRegistry,
     ) {
+    }
+
+    public function load(OutputInterface $output): Suite
+    {
         (new PhpHandler())->handle($this->options->configuration->php());
 
         if ($this->options->configuration->hasBootstrap()) {
@@ -125,7 +124,7 @@ final readonly class SuiteLoader
 
         (new TestSuiteFilterProcessor())->process($this->options->configuration, $testSuite);
 
-        $this->testCount = count($testSuite);
+        $testCount = count($testSuite);
 
         if ($this->options->functional) {
             // Functional: The unit of work is an individual test method.
@@ -154,24 +153,24 @@ final readonly class SuiteLoader
             $tests = array_keys($files);
         }
 
-        $this->tests = $tests;
+        $suite = new Suite($testCount, $tests);
 
-        if (! $this->options->configuration->hasCoverageReport()) {
-            return;
+        if ($this->options->configuration->hasCoverageReport()) {
+            ob_start();
+            $result       = (new WarmCodeCoverageCacheCommand(
+                $this->options->configuration,
+                $this->codeCoverageFilterRegistry,
+            ))->execute();
+            $ob_get_clean = ob_get_clean();
+            assert($ob_get_clean !== false);
+            $output->write($ob_get_clean);
+            $output->write($result->output());
+            if ($result->shellExitCode() !== Result::SUCCESS) {
+                exit($result->shellExitCode());
+            }
         }
 
-        ob_start();
-        $result       = (new WarmCodeCoverageCacheCommand(
-            $this->options->configuration,
-            $codeCoverageFilterRegistry,
-        ))->execute();
-        $ob_get_clean = ob_get_clean();
-        assert($ob_get_clean !== false);
-        $output->write($ob_get_clean);
-        $output->write($result->output());
-        if ($result->shellExitCode() !== Result::SUCCESS) {
-            exit($result->shellExitCode());
-        }
+        return $suite;
     }
 
     /** @return Generator<non-empty-string, (PhptTestCase|TestCase)> */

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -148,7 +148,7 @@ final class WrapperRunner implements RunnerInterface
     {
         $batchSize = $this->options->maxBatchSize;
 
-        while (!$this->pending->empty() && count($this->workers) > 0) {
+        while (! $this->pending->empty() && count($this->workers) > 0) {
             foreach ($this->workers as $token => $worker) {
                 if (! $worker->isRunning()) {
                     throw $worker->getWorkerCrashedException();
@@ -170,7 +170,7 @@ final class WrapperRunner implements RunnerInterface
                     && $this->options->configuration->stopOnFailureThreshold() > 0
                 ) {
                     $this->pending->clear();
-                } elseif (($pending = $this->pending->dequeue()) !== null) {
+                } elseif (($pending = $this->pending->dequeue($token)) !== null) {
                     $worker->assign($pending);
                     $this->batches[$token]++;
                 }

--- a/src/WrapperRunner/WrapperRunner.php
+++ b/src/WrapperRunner/WrapperRunner.php
@@ -33,7 +33,6 @@ use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_merge_recursive;
-use function array_shift;
 use function assert;
 use function count;
 use function dirname;
@@ -56,9 +55,8 @@ final class WrapperRunner implements RunnerInterface
     private const int CYCLE_SLEEP = 10000;
     private readonly ResultPrinter $printer;
 
-    /** @var list<non-empty-string> */
-    private array $pending = [];
-    private int $exitcode  = -1;
+    private PendingTestQueue $pending;
+    private int $exitcode = -1;
     /** @var array<positive-int,WrapperWorker> */
     private array $workers = [];
     /** @var array<int,int> */
@@ -124,13 +122,13 @@ final class WrapperRunner implements RunnerInterface
         ExcludeList::addDirectory(dirname(__DIR__));
         $suiteLoader = new SuiteLoader(
             $this->options,
-            $this->output,
             $this->codeCoverageFilterRegistry,
         );
+        $suite       = $suiteLoader->load($this->output);
         $result      = TestResultFacade::result();
 
-        $this->pending = $suiteLoader->tests;
-        $this->printer->setTestCount($suiteLoader->testCount);
+        $this->pending = PendingTestQueue::fromSuite($suite);
+        $this->printer->setTestCount($suite->getTestCount());
         $this->printer->start();
         $this->startWorkers();
         $this->assignAllPendingTests();
@@ -150,7 +148,7 @@ final class WrapperRunner implements RunnerInterface
     {
         $batchSize = $this->options->maxBatchSize;
 
-        while (count($this->pending) > 0 && count($this->workers) > 0) {
+        while (!$this->pending->empty() && count($this->workers) > 0) {
             foreach ($this->workers as $token => $worker) {
                 if (! $worker->isRunning()) {
                     throw $worker->getWorkerCrashedException();
@@ -171,8 +169,8 @@ final class WrapperRunner implements RunnerInterface
                     $this->exitcode > 0
                     && $this->options->configuration->stopOnFailureThreshold() > 0
                 ) {
-                    $this->pending = [];
-                } elseif (($pending = array_shift($this->pending)) !== null) {
+                    $this->pending->clear();
+                } elseif (($pending = $this->pending->dequeue()) !== null) {
                     $worker->assign($pending);
                     $this->batches[$token]++;
                 }

--- a/test/Unit/WrapperRunner/PendingTestQueueTest.php
+++ b/test/Unit/WrapperRunner/PendingTestQueueTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\Unit\WrapperRunner;
+
+use ParaTest\WrapperRunner\PendingTestQueue;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+#[CoversClass(PendingTestQueue::class)]
+final class PendingTestQueueTest extends TestCase
+{
+    public function testPopReturnsTestsInOrder(): void
+    {
+        $queue = PendingTestQueue::fromTests(['a', 'b']);
+
+        self::assertSame('a', $queue->dequeue());
+        self::assertSame('b', $queue->dequeue());
+        self::assertNull($queue->dequeue());
+    }
+
+    public function testCallingPopAgainReturnsNull(): void
+    {
+        $queue = PendingTestQueue::fromTests(['a']);
+
+        self::assertSame('a', $queue->dequeue());
+        self::assertNull($queue->dequeue());
+        self::assertNull($queue->dequeue());
+    }
+
+    public function testHandlesEmpty(): void
+    {
+        $queue = PendingTestQueue::fromTests([]);
+
+        self::assertNull($queue->dequeue());
+    }
+}

--- a/test/Unit/WrapperRunner/PendingTestQueueTest.php
+++ b/test/Unit/WrapperRunner/PendingTestQueueTest.php
@@ -16,24 +16,74 @@ final class PendingTestQueueTest extends TestCase
     {
         $queue = PendingTestQueue::fromTests(['a', 'b']);
 
-        self::assertSame('a', $queue->dequeue());
-        self::assertSame('b', $queue->dequeue());
-        self::assertNull($queue->dequeue());
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertSame('b', $queue->dequeue(1));
+        self::assertNull($queue->dequeue(1));
     }
 
     public function testCallingPopAgainReturnsNull(): void
     {
         $queue = PendingTestQueue::fromTests(['a']);
 
-        self::assertSame('a', $queue->dequeue());
-        self::assertNull($queue->dequeue());
-        self::assertNull($queue->dequeue());
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertNull($queue->dequeue(1));
+        self::assertNull($queue->dequeue(1));
     }
 
     public function testHandlesEmpty(): void
     {
         $queue = PendingTestQueue::fromTests([]);
 
-        self::assertNull($queue->dequeue());
+        self::assertNull($queue->dequeue(1));
+    }
+
+    public function testDifferentWorkerSkipsAlreadyAssignedAffinity(): void
+    {
+        $queue = new PendingTestQueue([
+            'a' => ['a', 'aa'],
+            'b' => ['b'],
+        ]);
+
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertSame('b', $queue->dequeue(2));
+    }
+
+    public function testWorkersWithoutAssignmentJoinOtherAffinitiesInOrder(): void
+    {
+        $queue = new PendingTestQueue([
+            'a' => ['a', 'aa', 'aaa'],
+            'b' => ['b', 'bb'],
+        ]);
+
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertSame('b', $queue->dequeue(2));
+        self::assertSame('aa', $queue->dequeue(3));
+        self::assertSame('bb', $queue->dequeue(4));
+    }
+
+    public function testWorkerJoinsOtherAffinitiesWhenOwnAssignmentIsDone(): void
+    {
+        $queue = new PendingTestQueue([
+            'a' => ['a', 'aa'],
+            'b' => ['b', 'bb'],
+            'c' => ['c'],
+        ]);
+
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertSame('b', $queue->dequeue(2));
+        self::assertSame('c', $queue->dequeue(3));
+        self::assertSame('aa', $queue->dequeue(3));
+        self::assertSame('bb', $queue->dequeue(3));
+    }
+
+    public function testHandlesNumericStringAffinity(): void
+    {
+        $queue = new PendingTestQueue([
+            '123' => ['a', 'aa'],
+        ]);
+
+        self::assertSame('a', $queue->dequeue(1));
+        self::assertSame('aa', $queue->dequeue(1));
+        self::assertNull($queue->dequeue(1));
     }
 }

--- a/test/Unit/WrapperRunner/SuiteLoaderTest.php
+++ b/test/Unit/WrapperRunner/SuiteLoaderTest.php
@@ -6,6 +6,7 @@ namespace ParaTest\Tests\Unit\WrapperRunner;
 
 use ParaTest\Tests\TestBase;
 use ParaTest\WrapperRunner\ShardDistribution;
+use ParaTest\WrapperRunner\Suite;
 use ParaTest\WrapperRunner\SuiteLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -37,15 +38,15 @@ final class SuiteLoaderTest extends TestBase
 
         $loader = $this->loadSuite();
 
-        self::assertSame(7, $loader->testCount);
-        self::assertCount(7, $loader->tests);
+        self::assertSame(7, $loader->getTestCount());
+        self::assertCount(7, $loader->getTests());
     }
 
     public function testLoadFileGetsPathOfFile(): void
     {
         $path                      = $this->fixture('common_results' . DIRECTORY_SEPARATOR . 'SuccessTest.php');
         $this->bareOptions['path'] = $path;
-        $files                     = $this->loadSuite()->tests;
+        $files                     = $this->loadSuite()->getTests();
 
         $file = array_shift($files);
         self::assertNotNull($file);
@@ -66,7 +67,7 @@ final class SuiteLoaderTest extends TestBase
     public function testLoadsPhptFiles(): void
     {
         $this->bareOptions['path'] = $this->fixture('phpt');
-        $files                     = $this->loadSuite()->tests;
+        $files                     = $this->loadSuite()->getTests();
 
         $file = array_shift($files);
         self::assertNotNull($file);
@@ -154,8 +155,8 @@ final class SuiteLoaderTest extends TestBase
         foreach ($expectedPerShard as $index => [$expectedFiles, $expectedTestCount]) {
             $this->bareOptions['--shard'] = ($index + 1) . '/' . $totalShards;
             $loader                       = $this->loadSuite();
-            self::assertSame($expectedFiles, array_map(basename(...), $loader->tests));
-            self::assertSame($expectedTestCount, $loader->testCount);
+            self::assertSame($expectedFiles, array_map(basename(...), $loader->getTests()));
+            self::assertSame($expectedTestCount, $loader->getTestCount());
         }
     }
 
@@ -210,8 +211,8 @@ final class SuiteLoaderTest extends TestBase
         foreach ($expectedPerShard as $index => [$expectedFiles, $expectedTestCount]) {
             $this->bareOptions['--shard'] = ($index + 1) . '/' . $totalShards;
             $loader                       = $this->loadSuite();
-            self::assertSame($expectedFiles, array_map(basename(...), $loader->tests));
-            self::assertSame($expectedTestCount, $loader->testCount);
+            self::assertSame($expectedFiles, array_map(basename(...), $loader->getTests()));
+            self::assertSame($expectedTestCount, $loader->getTestCount());
         }
     }
 
@@ -345,7 +346,7 @@ final class SuiteLoaderTest extends TestBase
     /** @return list<string> */
     private function loadSuiteFileNames(): array
     {
-        return array_map(basename(...), $this->loadSuite()->tests);
+        return array_map(basename(...), $this->loadSuite()->getTests());
     }
 
     /** @return list<string> */
@@ -356,13 +357,13 @@ final class SuiteLoaderTest extends TestBase
             self::assertSame(1, $result);
 
             return $matches[1];
-        }, $this->loadSuite()->tests);
+        }, $this->loadSuite()->getTests());
     }
 
-    private function loadSuite(): SuiteLoader
+    private function loadSuite(): Suite
     {
         $options = $this->createOptionsFromArgv($this->bareOptions);
 
-        return new SuiteLoader($options, $this->output, new CodeCoverageFilterRegistry());
+        return new SuiteLoader($options, new CodeCoverageFilterRegistry())->load($this->output);
     }
 }

--- a/test/Unit/WrapperRunner/SuiteLoaderTest.php
+++ b/test/Unit/WrapperRunner/SuiteLoaderTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+use function array_key_first;
 use function array_map;
 use function array_shift;
 use function basename;
@@ -341,6 +342,29 @@ final class SuiteLoaderTest extends TestBase
             $this->bareOptions['--shard'] = ($index + 1) . '/' . $totalShards;
             self::assertSame($expected, $this->loadSuiteMethodNames());
         }
+    }
+
+    public function testLoadsAffinityTests(): void
+    {
+        $this->bareOptions['path'] = $this->fixture('affinity');
+
+        $suite       = $this->loadSuite();
+        $perAffinity = $suite->getTestsPerAffinity();
+        self::assertCount(3, $perAffinity);
+        self::assertSame('A', array_key_first($perAffinity));
+        self::assertCount(2, $perAffinity['A']);
+    }
+
+    public function testLoadsAffinityTestsFunctional(): void
+    {
+        $this->bareOptions['path']         = $this->fixture('affinity');
+        $this->bareOptions['--functional'] = true;
+
+        $suite       = $this->loadSuite();
+        $perAffinity = $suite->getTestsPerAffinity();
+        self::assertCount(3, $perAffinity);
+        self::assertSame('A', array_key_first($perAffinity));
+        self::assertCount(3, $perAffinity['A']);
     }
 
     /** @return list<string> */

--- a/test/fixtures/affinity/AlphaTest.php
+++ b/test/fixtures/affinity/AlphaTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\affinity;
+
+use ParaTest\AffinityAware;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class AlphaTest extends TestCase implements AffinityAware
+{
+    public function getAffinity(): string|null
+    {
+        return 'A';
+    }
+
+    public function testOne(): void
+    {
+        self::assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/test/fixtures/affinity/AnotherAlphaTest.php
+++ b/test/fixtures/affinity/AnotherAlphaTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\affinity;
+
+use ParaTest\AffinityAware;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class AnotherAlphaTest extends TestCase implements AffinityAware
+{
+    public function getAffinity(): string|null
+    {
+        return 'A';
+    }
+
+    public function testThree(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/test/fixtures/affinity/BravoTest.php
+++ b/test/fixtures/affinity/BravoTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\affinity;
+
+use ParaTest\AffinityAware;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class BravoTest extends TestCase implements AffinityAware
+{
+    public function getAffinity(): string|null
+    {
+        return 'B';
+    }
+
+    public function testFour(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/test/fixtures/affinity/NotAwareTest.php
+++ b/test/fixtures/affinity/NotAwareTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\affinity;
+
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class NotAwareTest extends TestCase
+{
+    public function testFive(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/test/fixtures/affinity/NullTest.php
+++ b/test/fixtures/affinity/NullTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\fixtures\affinity;
+
+use ParaTest\AffinityAware;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class NullTest extends TestCase implements AffinityAware
+{
+    public function getAffinity(): string|null
+    {
+        return null;
+    }
+
+    public function testSix(): void
+    {
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
This contains a new feature to allow assigning affinities to tests by implementing an interface.

In our test suite we are relying quite a bit on caching state between (integration) tests. This mostly includes fixtures and compiled DI containers. Currently we mostly do the bookkeeping for this state in memory. This obviously won't be very effective in paratest because workers don't share this state.

An obvious solution is to move this state to the file system. That is definitely the most important part of the solution, but has a few missing parts:
* The locking you would use would also cause workers to be idle
* Not all state/caches are easily serializable to disk.
* It requires disk IO, which makes it unsuitable for slow-but-not-that-slow caches.
* and probably most relevant, its actually quite complicated to do well.

This PR allows tests to be assigned an affinity. This can be used on top of, or as an alternative to, handling this using the file system. Tests with the same affinity are more likely to run within the same worker, while tests with a different affinity will likely run in different workers. Existing behaviour is unchanged. The tests will run as they do currently when this functionality is not used.

Three commits:
* First one splits up some logic in the `SuiteLoader` which allowed for some dead code to be cleaned up.
* Second creates `Suite` and `PendingTestQueue` classes to contain state so the complexity from the new functionality is kept out of the `WrapperRunner` class. The `SuiteLoader` also got a drive-by change to become an actual "loader" that creates something using a "load" method.
* Third actually implements the feature and adds tests and a section to the readme.

The feature adds a new `AffinityAware` interface that would be added to the public api of paratest. Users of paratest can optionally choose to implement this interface and its `getAffinity` method. `getAffinity` can return any string or `null`. Return `null` is equivalent to not implementing the interface.

For our test suite this achieves a speedup of somewhere between 10% and 45%. See table at the bottom. This should be taken with a grain of salt, as this is without any disk based state which I would expect to have a similar effect. Still not too bad for what amounts to reordering the tests.

Some implementation choices that are probably reasonable though they can be improved in the future:
* In the current implementation a test having no affinity is considered being part of a default affinity.
* The scheduler is kept simple. Affinity buckets with the most tests are prioritized. It balances workers by minimizing worker count per affinity and does not consider the number of remaining tests per affinity.

It is probably also important to note that there are a couple of features in paratest/phpunit that are affected, though only if this feature is used:
* Sharding and its various strategies. This affinity should take priority over sharding I believe, and sharding would only apply within an affinity.
* Test order. Similar, affinity takes priority and test order only affects the ordering within an affinity.
* Functional. Affinities are assigned per test class and can't be different per test method.
* ... maybe more?

In the end the change here is a bit more involved than probably should have been done without prior discussion. Let me know if you'd like a different approach or don't like this at all.

Minor: the `make` command wants to make an unrelated change to the composer.json file, this has been kept out of the PR.

LLM disclaimer: Claude was used for review, but not for planning, code, tests or this PR.

Performance benchmarks:

| Scenario                                               | --functional | --max-processes | time before | time with affinities |
| ------------------------------------------------------ | ----------- | ------ | ----------- | -------------------- |
| Component "graphql", 465 tests, 7 affinities                   | no          | 2      | 0m56 - 1m00   | 0m45 - 0m55            |
| Component "graphql", 465 tests, 7 affinities                   | yes         | 4      | 1m00 - 1m23   | 0m47 - 0m49            |
| Component "graphql", 465 tests, 7 affinities                   | no          | 4      | 0m45 - 0m59   | 0m41 - 0m48            |
| Component "customization", 240 tests, 23 affinities                  | no          | 4      | 3m59 - 4m56   | 3m14 - 3m33            |
| Component "customization", 240 tests, 23 affinities                  | no          | 12     | 4m56 - 5m01   | 2m46 - 2m52            |
| All incl simple unit tests, 3827 tests, 41 affinities | no          | 2      | 9m46        | 8m17                 |
| All incl simple unit tests, 3827 tests, 41 affinities | no          | 12     | 8m30        | 5m14                 |
