### PR TITLE
fix: `--do-not-cache-result` CLI option is deprecated

### DIFF
--- a/src/WrapperRunner/WrapperWorker.php
+++ b/src/WrapperRunner/WrapperWorker.php
@@ -134,7 +134,7 @@ final class WrapperWorker
             }
         }
 
-        $phpunitArguments[] = '--do-not-cache-result';
+        $phpunitArguments[] = '--do-not-record-test-run-history';
         $phpunitArguments[] = '--no-logging';
         $phpunitArguments[] = '--no-coverage';
         $phpunitArguments[] = '--no-output';

--- a/test/TestBase.php
+++ b/test/TestBase.php
@@ -10,6 +10,7 @@ use ParaTest\RunnerInterface;
 use ParaTest\WrapperRunner\WrapperRunner;
 use PHPUnit\Event\Facade;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\TextUI\Configuration\Registry;
 use ReflectionProperty;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -68,7 +69,16 @@ abstract class TestBase extends TestCase
 
         $input = new ArrayInput($argv, $inputDefinition);
 
-        return Options::fromConsoleInput($input, $cwd ?? __DIR__);
+        // Backup the global PHPUnit registry instance and restore after building the Options object,
+        // or options set by tests will leak into all following tests.
+        $configurationRegistry = new ReflectionProperty(Registry::class, 'instance');
+        $registryBackup        = $configurationRegistry->getValue();
+
+        try {
+            return Options::fromConsoleInput($input, $cwd ?? __DIR__);
+        } finally {
+            $configurationRegistry->setValue(null, $registryBackup);
+        }
     }
 
     final protected function runRunner(): RunnerResult

--- a/test/Unit/WrapperRunner/WrapperRunnerTest.php
+++ b/test/Unit/WrapperRunner/WrapperRunnerTest.php
@@ -1243,12 +1243,6 @@ EOF;
         self::assertEquals(RunnerInterface::FAILURE_EXIT, $runnerResult->exitCode);
     }
 
-    /**
-     * ###   WARNING   ###
-     *
-     * This test MUST be the last of this file,
-     * otherwise the next one will always fail
-     */
     public function testProcessIsolation(): void
     {
         $this->bareOptions['path']                = $this->fixture('process_isolation' . DIRECTORY_SEPARATOR . 'FooTest.php');

--- a/test/Unit/WrapperRunner/WrapperWorkerTest.php
+++ b/test/Unit/WrapperRunner/WrapperWorkerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ParaTest\Tests\Unit\WrapperRunner;
+
+use ParaTest\Tests\TestBase;
+use ParaTest\WrapperRunner\WrapperWorker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(WrapperWorker::class)]
+final class WrapperWorkerTest extends TestBase
+{
+    public function testDisablesTestRunHistoryWithoutDeprecatedOption(): void
+    {
+        $output  = new BufferedOutput();
+        $options = $this->createOptionsFromArgv([
+            'path' => __FILE__,
+            '--verbose' => true,
+        ]);
+
+        new WrapperWorker($output, $options, ['phpunit-wrapper'], 1);
+
+        $command = $output->fetch();
+        self::assertStringContainsString('--do-not-record-test-run-history', $command);
+        self::assertStringNotContainsString('--do-not-cache-result', $command);
+    }
+}


### PR DESCRIPTION
superseedes #1127 by also fixing the `TestBase` which did not isolate PHPUnit options set by individual tests from the options of the suite run.
This was previously the reason for the warning above `WrapperRunnerTest::testProcessIsolation` and caused `WrapperWorker.php` (running after  `WrapperRunnerTest.php`) to fail.